### PR TITLE
fix: Usage of MPI_Comm when compiling without MPI support

### DIFF
--- a/lib/cgpt/lib/distribute.h
+++ b/lib/cgpt/lib/distribute.h
@@ -36,7 +36,9 @@ class cgpt_distribute {
  protected:
   struct mp { std::vector<long> src; std::vector<long> dst; };
   void split(const std::vector<coor>& c, std::map<int,mp>& s);
+  #if defined (GRID_COMMS_MPI3)
   MPI_Comm comm;
+  #endif
   int mpi_ranks, mpi_rank;
   std::vector<int> mpi_rank_map;
 


### PR DESCRIPTION
In addition to commit https://github.com/lehner/gpt/commit/890a3f64d04fe1154f72fbfd3e9d64054de7d79f which fixes the segfault, the commit of this pull request resolves issue https://github.com/lehner/gpt/issues/5 for me.