### PR TITLE
Do not add cgpt/lib to include path

### DIFF
--- a/lib/cgpt/Makefile.am
+++ b/lib/cgpt/Makefile.am
@@ -38,7 +38,6 @@ cgpt_la_LDFLAGS = -avoid-version -module -export-dynamic -shared
 # cgpt_la_CFLAGS = $(PYTHON_CFLAGS) $(GRID_CFLAGS)
 cgpt_la_CXXFLAGS = $(PYTHON_INCLUDES) $(GRID_CXXFLAGS)
 cgpt_la_CPPFLAGS = $(PYTHON_INCLUDES) $(GRID_CPPFLAGS) \
-		   -I$(builddir)/lib \
 		   -I$(GRID_PREFIX)/include \
 		   -I$(NUMPY_INCLUDE)
 cgpt_la_LIBADD = -L$(GRID_PREFIX)/lib -lGrid \


### PR DESCRIPTION
Depending on the order the compiler looks for files in include paths
this causes issues as headers in cgpt/lib may overwrite global headers.
In this particular case cgpt/lib/time.h was included instead of
/usr/include/time.h (for get_clocktime).
This should not be an issue as no cgpt headers are included via "<>".
Was actually required to find the non-used config.h. With the changes in the
mean-time this file is now in topdir - this directory is still added as
include path.

Fixes compilation on CentOS 8.