### PR TITLE
Feature/speedup compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,13 @@ AC_DEFUN([PYTHON_MIN_VERSION],[3.6])
 
 # project name, version and maintainer's address
 AC_INIT([gpt],[0.1],[christoph.lehner@ur.de])
-AM_INIT_AUTOMAKE
+
+# Use automake
+# the next macro takes a space separated list of arguments.
+# First argument is the minimal automake version. foreign means that
+# you don't follow GNU standards (ChangeLog COPYING files etc.)
+# and -Wall turns on all automake warnings.
+AM_INIT_AUTOMAKE([1.15.1 foreign subdir-objects -Wall])
 
 # separate directory for m4 stuff (libtools prefers this)
 AC_CONFIG_MACRO_DIR([m4])
@@ -150,13 +156,6 @@ AS_IF([expr "${$1}" : ".*$2 " > /dev/null],
 for token in -Xlinker -Xcompiler; do
 fixxer([GRID_CXXFLAGS],${token})
 done
-
-# Use automake
-# the next macro takes a space separated list of arguments.
-# First argument is the minimal automake version. foreign means that
-# you don't follow GNU standards (ChangeLog COPYING files etc.)
-# and -Wall turns on all automake warnings.
-AM_INIT_AUTOMAKE([1.15.1 foreign subdir-objects -Wall])
 
 # Makefiles to be generated. These are all *.in  files.
 # We have to use subdirs, because for the python files I need to

--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ AC_CONFIG_HEADERS([config.h])
 AM_PROG_AR
 
 # need for dynamic libraries (no need for ranlib)
-LT_INIT
+LT_INIT([disable-static])
 
 AC_ARG_WITH(python,
             AS_HELP_STRING([--with-python=PATH],[Path to Python interpreter. Searches $PATH if only a program name is given]),


### PR DESCRIPTION
By disabling static builds by default compilation time of cgpt is approx. halved.

Previously all .cc have been compiled twice for unknown reasons. Once with -fPIC, once without.
- The files without -fPIC have been used to link a static cgpt library.
- The files with -fPIC have been used to link a shared cgpt library.

However the static one has been deleted/overwritten in a later step. I do not know why it was built in the first place.

We should understand why before we change this.

@ssolbUR Any ideas what's going on?