### PR TITLE
Change compiler loading and other stuff

### DIFF
--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install Ubuntu packages
       run: |
-        sudo apt-get install -y cmake clang-9 libmpfr-dev libgmp-dev libssl-dev zlib1g-dev libmpich-dev libopenmpi-dev
+        sudo apt-get install -y clang-9 libmpfr-dev libgmp-dev libssl-dev zlib1g-dev libmpich-dev libopenmpi-dev
 
     - name: Set Compiler Variables GCC
       if: matrix.compiler == 'gcc'
@@ -168,7 +168,7 @@ jobs:
 
     - name: Install Ubuntu packages
       run: |
-        sudo apt-get install -y cmake clang-9 libmpfr-dev libgmp-dev libssl-dev zlib1g-dev libmpich-dev libopenmpi-dev
+        sudo apt-get install -y clang-9 libmpfr-dev libgmp-dev libssl-dev zlib1g-dev libmpich-dev libopenmpi-dev
 
     - name: Set Compiler Variables GCC
       if: matrix.compiler == 'gcc'
@@ -317,7 +317,7 @@ jobs:
 
     - name: Install Ubuntu packages
       run: |
-        sudo apt-get install -y cmake clang-9 libmpfr-dev libgmp-dev libssl-dev zlib1g-dev libmpich-dev libopenmpi-dev
+        sudo apt-get install -y clang-9 libmpfr-dev libgmp-dev libssl-dev zlib1g-dev libmpich-dev libopenmpi-dev
 
     - name: Set Compiler Variables GCC
       if: matrix.compiler == 'gcc'

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -86,7 +86,7 @@ jobs:
         mkdir -p $PKGDIR
         cd c-lime
         ./autogen.sh
-        ./configure
+        ./configure || cat config.log
         make ${MAKE_BUILD_FLAGS}
         DESTDIR=$PKGDIR make install
 
@@ -118,9 +118,9 @@ jobs:
 
         if [ "${{ matrix.mpi }}" == "none" ]
         then
-            ../configure CXXFLAGS=-fPIC --enable-simd=AVX2
+            ../configure CXXFLAGS=-fPIC --enable-simd=AVX2 || cat config.log
         else
-            ../configure CXXFLAGS=-fPIC --enable-simd=AVX2 --enable-comms=mpi-auto
+            ../configure CXXFLAGS=-fPIC --enable-simd=AVX2 --enable-comms=mpi-auto || cat config.log
         fi
 
         cd Grid
@@ -259,7 +259,7 @@ jobs:
         ./bootstrap.sh
         mkdir -p build
         cd build
-        ../configure --disable-gpt
+        ../configure --disable-gpt || cat config.log
         make ${MAKE_BUILD_FLAGS}
         DESTDIR=$PKGDIR make install
 
@@ -290,7 +290,7 @@ jobs:
         ./bootstrap.sh
         mkdir -p build
         cd build
-        ../configure --disable-cgpt
+        ../configure --disable-cgpt || cat config.log
         make ${MAKE_BUILD_FLAGS}
         DESTDIR=$PKGDIR make install
 

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -425,3 +425,4 @@ jobs:
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
         cd gpt/tests
         ./run "mpirun -np 1 python" "--mpi 1.1.1.1"
+        ./run "mpirun -np 2 -bind-to core python" "--mpi 1.1.1.2"

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -7,6 +7,12 @@ on:
 env:
   MAKE_BUILD_FLAGS: -j2
   GRID_REPOSITORY_REF: feature/gpt
+  CC: mpicc
+  CXX: mpic++
+  OMPI_CC: cc
+  OMPI_CXX: c++
+  MPICH_CC: cc
+  MPICH_CXX: c++
 
 jobs:
   build-grid:
@@ -41,6 +47,12 @@ jobs:
         sudo update-alternatives --set c++ /usr/bin/clang++-9
 
         echo '::set-env name=LDFLAGS::-lomp'
+
+    - name: Set compiler to cc and c++
+      if: matrix.mpi == 'none'
+      run: |
+        echo '::set-env name=CC::cc'
+        echo '::set-env name=CXX::c++'
 
     - name: Set MPI alternatives to mpich
       if: matrix.mpi == 'mpich'

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -415,9 +415,9 @@ jobs:
       run: |
         cd gpt/tests
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
-        export LD_PRELOAD=libmpi.so
         mpirun -np 2 -mca btl ^openib -bind-to core python core/scalar.py --mpi 1.1.1.2
-        ./run "mpirun -np 1 -mca btl ^openib python" "--mpi 1.1.1.1" && ./run "mpirun -np 2 -bind-to core -mca btl ^openib python" "--mpi 1.1.1.2"
+        ./run "mpirun -np 1 -mca btl ^openib python" "--mpi 1.1.1.1"
+        ./run "mpirun -np 2 -bind-to core -mca btl ^openib python" "--mpi 1.1.1.2"
 
     - name: Run tests
       if: matrix.mpi == 'mpich'

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -13,6 +13,8 @@ env:
   OMPI_CXX: c++
   MPICH_CC: cc
   MPICH_CXX: c++
+  # Note if this is changed, all caches will be not be valid anymore
+  CACHE_KEY: v2
 
 jobs:
   build-grid:
@@ -70,7 +72,7 @@ jobs:
       id: c-lime-version
       run: |
         cd c-lime
-        echo "::set-output name=key::$(git rev-parse HEAD)-v1"
+        echo "::set-output name=key::$(git rev-parse HEAD)-${CACHE_KEY}"
 
     - name: c-lime package cache
       uses: actions/cache@v2
@@ -125,7 +127,7 @@ jobs:
 
         cd Grid
         make version-cache Version.h
-        echo "::set-output name=key::$(sha256sum version-cache|cut -f 1 -d " ")-v1"
+        echo "::set-output name=key::$(sha256sum version-cache|cut -f 1 -d " ")-${CACHE_KEY}"
 
     - name: Grid package cache
       uses: actions/cache@v2
@@ -236,12 +238,12 @@ jobs:
     - name: Get cgpt cache key
       id: cgpt-version
       run: |
-        echo "::set-output name=key::${{ hashFiles('gpt/lib/cgpt/lib/**') }}-v1"
+        echo "::set-output name=key::${{ hashFiles('gpt/lib/cgpt/lib/**') }}-${CACHE_KEY}"
 
     - name: Get gpt cache key
       id: gpt-version
       run: |
-        echo "::set-output name=key::${{ hashFiles('gpt/lib/gpt/**') }}-v1"
+        echo "::set-output name=key::${{ hashFiles('gpt/lib/gpt/**') }}-${CACHE_KEY}"
 
     - name: cgpt package cache
       uses: actions/cache@v2

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -412,6 +412,8 @@ jobs:
 
     - name: Run tests
       if: matrix.mpi == 'openmpi'
+      env:
+        LD_PRELOAD: libmpi.so
       run: |
         cd gpt/tests
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -31,17 +31,15 @@ jobs:
       run: |
         sudo apt-get install -y clang-9 libmpfr-dev libgmp-dev libssl-dev zlib1g-dev libmpich-dev libopenmpi-dev
 
-    - name: Set Compiler Variables GCC
-      if: matrix.compiler == 'gcc'
-      run: |
-        echo '::set-env name=CC::gcc'
-        echo '::set-env name=CXX::g++'
-
-    - name: Set Compiler Variables CLANG
+    - name: Set compiler alternatives to clang-9
       if: matrix.compiler == 'clang'
       run: |
-        echo '::set-env name=CC::clang-9'
-        echo '::set-env name=CXX::clang++-9'
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-9 1
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-9 1
+
+        sudo update-alternatives --set cc /usr/bin/clang-9
+        sudo update-alternatives --set c++ /usr/bin/clang++-9
+
         echo '::set-env name=LDFLAGS::-lomp'
 
     - name: Set MPI alternatives to mpich
@@ -170,17 +168,14 @@ jobs:
       run: |
         sudo apt-get install -y clang-9 libmpfr-dev libgmp-dev libssl-dev zlib1g-dev libmpich-dev libopenmpi-dev
 
-    - name: Set Compiler Variables GCC
-      if: matrix.compiler == 'gcc'
-      run: |
-        echo '::set-env name=CC::gcc'
-        echo '::set-env name=CXX::g++'
-
-    - name: Set Compiler Variables CLANG
+    - name: Set compiler alternatives to clang-9
       if: matrix.compiler == 'clang'
       run: |
-        echo '::set-env name=CC::clang-9'
-        echo '::set-env name=CXX::clang++-9'
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-9 1
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-9 1
+
+        sudo update-alternatives --set cc /usr/bin/clang-9
+        sudo update-alternatives --set c++ /usr/bin/clang++-9
         echo '::set-env name=LDFLAGS::-lomp'
 
     - name: Set MPI alternatives to mpich
@@ -319,17 +314,14 @@ jobs:
       run: |
         sudo apt-get install -y clang-9 libmpfr-dev libgmp-dev libssl-dev zlib1g-dev libmpich-dev libopenmpi-dev
 
-    - name: Set Compiler Variables GCC
-      if: matrix.compiler == 'gcc'
-      run: |
-        echo '::set-env name=CC::gcc'
-        echo '::set-env name=CXX::g++'
-
-    - name: Set Compiler Variables CLANG
+    - name: Set compiler alternatives to clang-9
       if: matrix.compiler == 'clang'
       run: |
-        echo '::set-env name=CC::clang-9'
-        echo '::set-env name=CXX::clang++-9'
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-9 1
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-9 1
+
+        sudo update-alternatives --set cc /usr/bin/clang-9
+        sudo update-alternatives --set c++ /usr/bin/clang++-9
         echo '::set-env name=LDFLAGS::-lomp'
 
     - name: Set MPI alternatives to mpich


### PR DESCRIPTION
I tried to work around the LD_PRELOAD using the `mpicc` and `mpic++` compiler wrapper, as suggested by @pjgeorg :-)
Unfortunately this does not work on Ubuntu, see this commit message (credits also to @pjgeorg):
https://github.com/lehner/gpt/commit/fb83582114c0d27e4c99d40d01bbd3ae23700b7d

Doing this I also unified the compiler variables in the sanest way I could imagine (using Ubuntu) :-)
I think in principle this way it is still better to setup the compilers. Therefore I would include this upstream.

I also included the `mpich`-tests with the same mpirun flag as for `openmpi`, this seems to work:
https://github.com/aragon999/gpt/actions/runs/123729515