### PR TITLE
Feature/RQCD Update refs and add condition on secrets

### DIFF
--- a/.github/workflows/rqcd.yml
+++ b/.github/workflows/rqcd.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cluster: ['master', 'qp4']
+        cluster: ['x86/avx2', 'x86/avx512', 'x86/cuda', 'arm/sve',]
 
     steps:
     - name: Check for secrets

--- a/.github/workflows/rqcd.yml
+++ b/.github/workflows/rqcd.yml
@@ -7,18 +7,34 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      ca-bundle: ${{ secrets.RQCD_CA_BUNDLE }}
+      token: ${{ secrets.RQCD_TRIGGER_TOKEN }}
+
     strategy:
       fail-fast: false
       matrix:
         cluster: ['master', 'qp4']
 
     steps:
+    - name: Check for secrets
+      id: check
+      shell: bash
+      run: |
+        if [ "${{ env.ca-bundle }}" != "" ] && [ "${{ env.token }}" != "" ]
+        then
+          echo ::set-output name=secrets::'true'
+        else
+          echo "Do not trigger RQCD CI as at least one of the secrets is missing."
+        fi
+
     - name: Trigger CI Job
+      if: ${{ steps.check.outputs.secrets }}
       uses: pjgeorg/gitlab-trigger-ci@v2
       with:
         host: "rqcd.ur.de"
         port: 8443
-        ca-bundle: ${{ secrets.RQCD_CA_BUNDLE }}
+        ca-bundle: ${{ env.ca-bundle }}
         project-id: 888
-        token: ${{ secrets.RQCD_TRIGGER_TOKEN }}
+        token: ${{ env.token }}
         ref:  ${{ matrix.cluster }}


### PR DESCRIPTION
This PR includes:
- Change the RQCD action to only trigger if the required secrets are available as requested by @aragon999
- Rename the existing refs master and qp4 to non-RQCD human readable name x86/avx2 and arm/sve
- Add additional refs x86/avx512 and x86/cuda

Current state on the RQCD CI implementation side:
- x86/avx2 is fully implemented
- x86/avx512 only builds grid and gpt. Tests are not being run (yet).
- x86/cuda is a dummy for now
- arm/sve is a dummy for now

I added the dummy refs to avoid having to open a PR again later. These actions will currently do nothing and just simply pass.

A remark about the x86/avx512 target (copied from commit: https://rqcd.ur.de:8443/clehner/gpt-ci/-/commit/0be21ef1a07c7893ac8bcddbe2dc387e0a7e248d):

> Despite running on KNL, set SIMD to AVX512 not KNL.
>There are currently 3 different SIMD "targets" for AVX512 in grid:
>
>- KNL: Build for KNL arch, i.e. binaries only for KNL (and KNM)
>      Enables KNL specific code paths in grid.
>         * Performance counters
>         * Different LebesgueOrder
>- SKL: Build for Skylake-SP arch, i.e. binaries for SKL-SP and future
>- AVX512: Build with AVX512F, CD, ER, PF. I.e. binaries only for KNL
>          (and KNM)
>          Does not enable any KNL specific code paths
>
>The last one is probably unintended. I expected AVX512 to build for
>generic AVX512, i.e. only with F and CD enabled. This would then have
>allowed to cover a broader range of hardware with only one test.

I don't know of any planned future Intel architecture to actually support AVX512 ER and PF. These will probably never be supported by anything but KNL/KNM.

Any comment about this behavior by the Grid experts @lehner @DanielRichtmann ? Should we try to get it changed upstream?