### PR TITLE
Feature/autotools Only ask grid-config for --prefix if not known yet

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,9 @@ AM_INIT_AUTOMAKE([1.15.1 foreign subdir-objects -Wall])
 # separate directory for m4 stuff (libtools prefers this)
 AC_CONFIG_MACRO_DIR([m4])
 
+# C++ -Compiler
+AC_PROG_CXX
+
 # use configure header
 AC_CONFIG_HEADERS([config.h])
 
@@ -34,45 +37,30 @@ AM_PROG_AR
 LT_INIT([disable-static])
 
 AC_ARG_ENABLE([cgpt],
-    AS_HELP_STRING([--disable-cgpt], [Disable building cgpt]))
+              AS_HELP_STRING([--disable-cgpt], [Disable building cgpt]))
 AC_ARG_ENABLE([gpt],
-    AS_HELP_STRING([--disable-gpt], [Disable instaling gpt]))
+              AS_HELP_STRING([--disable-gpt], [Disable instaling gpt]))
 
 AC_ARG_WITH(python,
-            AS_HELP_STRING([--with-python=PATH],[Path to Python interpreter. Searches $PATH if only a program name is given]),
+            AS_HELP_STRING([--with-python=PATH],
+                           [Path to Python interpreter. Searches $PATH if only a program name is given]),
             [PYTHON="$withval"], [])
 
-if test x"$PYTHON" = xyes
-then
-    AC_MSG_ERROR([--with-python option requires a path or program argument])
-fi
-
-if test x"$PYTHON" = xno
-then
-    AC_MSG_ERROR([Python is non-optional])
-fi
-
-if test x"$PYTHON" = x
-then
-    PYTHON="python3"
-fi
-
 AC_MSG_CHECKING(for Python interpreter)
-if ! which "$PYTHON"
-then
-    AC_MSG_ERROR([Python interpreter $PYTHON does not exist])
-fi
+AS_IF([test x"$PYTHON" = xno],
+      [AC_MSG_ERROR([Python is non-optional])],
+      [test x"$PYTHON" = x || test x"$PYTHON" = x"yes"],
+      [PYTHON="python3"],
+      [which "$PYTHON"],
+      [],
+      [AC_MSG_ERROR([Python interpreter $PYTHON does not exist])])
 
 AM_PATH_PYTHON([PYTHON_MIN_VERSION])
 
 AC_MSG_CHECKING([for the sysconfig Python module])
-if $PYTHON -c "import sysconfig"
-then
-    AC_MSG_RESULT([yes])
-else
-    AC_MSG_RESULT([no])
-    AC_MSG_ERROR([cannot import Python module "sysconfig"])
-fi
+AS_IF(["$PYTHON" -c "import sysconfig"],
+      [AC_MSG_RESULT([yes])],
+      [AC_MSG_ERROR([no])])
 
 AC_MSG_CHECKING([for Python include paths])
 PYTHON_INCLUDES=`$PYTHON -c "import sysconfig; \
@@ -84,103 +72,90 @@ ac_save_CPPFLAGS="$CPPFLAGS"
 CPPFLAGS="$ac_save_CPPFLAGS $PYTHON_INCLUDES"
 AC_CHECK_HEADER(Python.h,
                 [],
-                [if test x$enable_cgpt != xno
-                 then
-                     AC_MSG_ERROR([Missing Python.h])
-                 fi
-                 ])
+                [AS_IF([test x$enable_cgpt != xno],
+                       [AC_MSG_ERROR([Missing Python.h])],
+                       [])
+                ])
 CPPFLAGS="$ac_save_CPPFLAGS"
 
-# Numpy include dir
-AC_DEFUN([numpy_includer],["${PYTHON}" -c 'import numpy; print(numpy.get_include())'])
+AC_MSG_CHECKING([for the numpy Python module])
+AS_IF(["$PYTHON" -c "import numpy"],
+      [AC_MSG_RESULT([yes])],
+      [AC_MSG_ERROR([no])])
+
+AC_MSG_CHECKING([for numpy include paths])
+NUMPY_INCLUDE=`$PYTHON -c "import numpy; \
+    print(numpy.get_include());"`
+AC_MSG_RESULT([$NUMPY_INCLUDE])
 AC_SUBST([NUMPY_INCLUDE])
-AC_MSG_CHECKING([for numpy headers])
-AS_IF([numpy_includer > /dev/null 2>&1 ],
-      [NUMPY_INCLUDE="$(numpy_includer)"
-       AC_MSG_RESULT([${NUMPY_INCLUDE}])],
-      [if test x$enable_cgpt != xno
-       then
-           AC_MSG_ERROR([no])
-       else
-           AC_MSG_RESULT([no])
-       fi
-       ])
 
 AC_ARG_WITH(grid,
-    AS_HELP_STRING(
-        [--with-grid=DIR],
-        [Specify grid installation directory DIR]
-  ),
-  [GRID_HOME="$with_grid"]
-)
+            AS_HELP_STRING([--with-grid=DIR],
+                           [Specify grid installation directory DIR]),
+            [GRID_PREFIX="$withval"], [])
 
 AC_ARG_ENABLE([fake-grid],
               [AS_HELP_STRING([--enable-fake-grid],
-                              [Fake grid-config. Useful if you just want
-                               to do a 'make dist'])],
+                              [Fake grid-config. Useful if you just want to do a 'make dist'])],
               [ac_fake_grid=yes],
               [ac_fake_grid=no])
 
-AS_IF([test "x${ac_fake_grid}" = "xyes"],
-[
-    AC_SUBST([GRID_CXXFLAGS],[-DFAKEGRID])
-    AC_SUBST([GRID_LDFLAGS],[-LFAKEGRID])
-    AC_SUBST([GRID_CXX],[gcc])
-    AC_SUBST([GRID_CXXLD],[gcc])
-    AC_SUBST([GRID_LIBS],  [-lFAKEGRID])
-    AC_SUBST([GRID_PREFIX],[FAKEGRID])
-],
-[
-AS_IF([test x"${GRID_HOME}" = x],
-    [AC_PATH_PROG(GRID_CONFIG, [grid-config], [])],
-    [AC_PATH_PROG(GRID_CONFIG, [grid-config], [], [${GRID_HOME}/bin:${PATH}])])
-
-if test x"${GRID_CONFIG}" = x
-then
-    if test x$enable_cgpt != xno
-    then
-      AC_MSG_ERROR([cannot find grid-config])
-    fi
-else
-    AC_SUBST([GRID_CXXFLAGS],[`${GRID_CONFIG} --cxxflags`])
-    AC_SUBST([GRID_LDFLAGS],[`${GRID_CONFIG} --ldflags`])
-    AC_SUBST([GRID_CXX],[`${GRID_CONFIG} --cxx`])
-    AC_SUBST([GRID_CXXLD],[`${GRID_CONFIG} --cxxld`])
-    AC_SUBST([GRID_LIBS],  [`${GRID_CONFIG} --libs`])
-    AC_SUBST([GRID_PREFIX],[`${GRID_CONFIG} --prefix`])
-fi
-])
+AS_IF([test x"${ac_fake_grid}" = x"yes"],
+      [
+       AC_SUBST([GRID_CXXFLAGS],[-DFAKEGRID])
+       AC_SUBST([GRID_LDFLAGS],[-LFAKEGRID])
+       AC_SUBST([GRID_CXX],[gcc])
+       AC_SUBST([GRID_CXXLD],[gcc])
+       AC_SUBST([GRID_LIBS],[-lFAKEGRID])
+       AC_SUBST([GRID_PREFIX],[FAKEGRID])
+      ],
+      [
+       AS_IF([test x"$GRID_PREFIX" = x"no"],
+             [],
+             [test x"$GRID_PREFIX" = x || test x"$GRID_PREFIX" = x"yes"],
+             [AC_PATH_PROG(GRID_CONFIG, [grid-config], [])],
+             [AC_PATH_PROG(GRID_CONFIG, [grid-config], [], [$GRID_PREFIX/bin:$PATH])])
+       AS_IF([test x"$GRID_CONFIG" = x],
+             [
+              AS_IF([test x"enable_cgpt" != x"no"],
+                    [AC_MSG_ERROR([cannot find grid-config])],
+                    [])
+             ],
+             [
+              AC_SUBST([GRID_CXXFLAGS],[`${GRID_CONFIG} --cxxflags`])
+              AC_SUBST([GRID_LDFLAGS],[`${GRID_CONFIG} --ldflags`])
+              AC_SUBST([GRID_CXX],[`${GRID_CONFIG} --cxx`])
+              AC_SUBST([GRID_CXXLD],[`${GRID_CONFIG} --cxxld`])
+              AC_SUBST([GRID_LIBS],  [`${GRID_CONFIG} --libs`])
+              AC_SUBST([GRID_PREFIX],[`${GRID_CONFIG} --prefix`])
+             ])
+       ])
 
 # Unfortunately, not all versions of Grid have --cxxld and it does
 # not print to stderr in case of an error. So detect error by
 # matching the output to Usage:
-
 AS_IF([expr "${GRID_CXXLD}" : ".*Usage:" > /dev/null],
       [GRID_CXXLD=])
 
 # If GRID_CXXLD is unset or null, use GRID_CXX.
 # Set CXX to GRID_CXX if CXX is unset or null. This means, by default
 # use Grid's CXX, but user can override it.  Same for GRID_CXXLD.
-
 : ${GRID_CXXLD:=${GRID_CXX}}
 : ${CXX:=${GRID_CXX}}
 : ${CXXLD:=${GRID_CXXLD}}
-
-# C++ -Compiler
-AC_PROG_CXX
 
 # The following code tries to fix nvcc (and possibly other weird
 # compilers) that take an -Xcompiler or -Xlinker argument flag.
 # These flags are also used by GNU libtool, hence a conflict arises.
 # Fix the conflict by 'escaping' the problematic flags.
-
 AC_PROG_SED
 AC_DEFUN([fixxer],[# The FiXXer
 AS_IF([expr "${$1}" : ".*$2 " > /dev/null],
       [$1=`echo "${$1}" | ${SED} -e "s/$2 /$2 $2 $2 /g"`])])
 
-for token in -Xlinker -Xcompiler; do
-fixxer([GRID_CXXFLAGS],${token})
+for token in -Xlinker -Xcompiler
+do
+    fixxer([GRID_CXXFLAGS],${token})
 done
 
 # Makefiles to be generated. These are all *.in  files.

--- a/configure.ac
+++ b/configure.ac
@@ -127,7 +127,9 @@ AS_IF([test x"${ac_fake_grid}" = x"yes"],
               AC_SUBST([GRID_CXX],[`${GRID_CONFIG} --cxx`])
               AC_SUBST([GRID_CXXLD],[`${GRID_CONFIG} --cxxld`])
               AC_SUBST([GRID_LIBS],  [`${GRID_CONFIG} --libs`])
-              AC_SUBST([GRID_PREFIX],[`${GRID_CONFIG} --prefix`])
+              AS_IF([test x"$GRID_PREFIX" = x || test x"$GRID_PREFIX" = x"yes"],
+                    [AC_SUBST([GRID_PREFIX],[`${GRID_CONFIG} --prefix`])],
+                    [])
              ])
        ])
 


### PR DESCRIPTION
Working on RQCD CI gpt setup I updated the autotools setup to not use the path provided by `grid-config --prefix` if a grid prefix has been specified by --with-grid=DIR.

grid-config stores an absolute path to the directory grid has been installed to. Not relying on this path allows compiling gpt against a libGrid.a that has been moved (or simply accessed through a different path). This is the case for our CI setup as various IDs to specifiy a CI job are included in the path. Without this change, using a grid installation compiled by a previous CI job (via cache or artifacts) is not possible. This is not an issue on GitHub CI as everything is installed to /usr/local as user root. On RQCD and other systems, CI jobs may not run as root (or use sudo).

When implementing this it wasn't obvious to me where the new condition is required due to the grown complexity of all existing condition checks. Hence I first simplified the current setup (now using AS_IF consistently).