### PR TITLE
Add GithubActions lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,46 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+          architecture: x64
+
+      - name: Clone gpt
+        uses: actions/checkout@v2
+
+      - name: Install linters
+        id: install-linters
+        run: pip install flake8 black # cpplint
+
+      # - name: Run cpplint
+      #   if: always()
+      #   run: |
+      #     cpplint --extensions=cc,h --headers=h --recursive .
+
+      - name: Run black
+        if: always()
+        run: |
+          black --check -q lib/gpt || exit_code=$?
+
+          if [ ${exit_code} -ne 0 ]; then
+              black --diff -q lib/gpt
+          fi
+
+      - name: Run flake8
+        if: always()
+        run: |
+          flake8 \
+            --format="::error file=%(path)s,line=%(row)s,col=%(col)s::%(code)s:%(text)s" \
+            --ignore="E203,E401,E501,W503,F401,F403,F405,E741,E302" \
+            --max-line-length=100 lib/gpt > tmp_flake.log || true
+
+          cat tmp_flake.log


### PR DESCRIPTION
This is an automated linting action, where the flake8 output is annotated, see for example the test pull request:
https://github.com/aragon999/gpt/pull/4/files
And the following commit:
https://github.com/aragon999/gpt/commit/ef133a6aa8f4e4d47451a3b5164f7f06fbd10b2b

Normally either the `pull_request` or `push` should occur, therefore there should be not so many double annotations, as in this case. The only way I could think of, is to disable it for one of the two events.

Furthermore black is used to check the python files and if an error is found, the diff is displayed.

This job should never fail due to some linting errors. 

I also found [`cpplint`](https://github.com/cpplint/cpplint) which could fit nice into the lint workflow. But this is just a suggestion, therefore I left it there. 
It is basically the same as flake8, such that one can disable different warnings (using for example: `--filter=--filter=-whitespace`, see also here: https://stackoverflow.com/a/45667936).