### PR TITLE
Fix ghaction black job if no lint errors were found

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           black --check -q lib/gpt || exit_code=$?
 
-          if [ ${exit_code} -ne 0 ]; then
+          if [[ "${exit_code}" -ne "0" ]]; then
               black --diff -q lib/gpt
           fi
 


### PR DESCRIPTION
Minor bash error, compare "run black" in the following action runs:
https://github.com/aragon999/gpt/runs/879447008?check_suite_focus=true
https://github.com/lehner/gpt/runs/877596105?check_suite_focus=true