### PR TITLE
Feature/code coverage

### DIFF
--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -442,7 +442,6 @@ jobs:
       run: |
         cd gpt
         coverage combine
-        ls -lha
         coverage report -m  # Print coverage report to screen
         coverage xml  # Export coverage report as XML file, for codecov.io
 

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -428,8 +428,8 @@ jobs:
         cd gpt/tests
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
         mpirun -np 2 -mca btl ^openib -bind-to core python core/scalar.py --mpi 1.1.1.2
-        ./run "coverage run mpirun -np 1 -mca btl ^openib python"
-        ./run "coverage run mpirun -np 2 -bind-to core -mca btl ^openib python" "--mpi 1.1.1.2 --mpi 1.1.2"
+        ./run "mpirun -np 1 -mca btl ^openib coverage run"
+        ./run "mpirun -np 2 -bind-to core -mca btl ^openib coverage run --parallel-mode" "--mpi 1.1.1.2 --mpi 1.1.2"
         coverage report -m
 
     - name: Run tests
@@ -437,8 +437,8 @@ jobs:
       run: |
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
         cd gpt/tests
-        ./run "coverage run mpirun -np 1 python"
-        ./run "coverage run mpirun -np 2 -bind-to core python" "--mpi 1.1.1.2 --mpi 1.1.2"
+        ./run "mpirun -np 1 coverage run"
+        ./run "mpirun -np 2 -bind-to core coverage run --parallel-mode" "--mpi 1.1.1.2 --mpi 1.1.2"
         coverage report -m
 
 

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -153,10 +153,6 @@ jobs:
         cd -
         dpkg-deb --build $PKGDIR
 
-    - name: Install Grid
-      run: |
-        sudo dpkg -i grid-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.mpi }}.deb
-
 
   build-gpt:
     needs: build-grid
@@ -294,10 +290,6 @@ jobs:
         cd -
         dpkg-deb --build $PKGDIR
 
-    - name: Install cgpt
-      run: |
-        sudo dpkg -i cgpt-${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.compiler }}-${{ matrix.mpi }}.deb
-
     - name: gpt package cache
       uses: actions/cache@v2
       id: gpt-package-cache
@@ -324,10 +316,6 @@ jobs:
         sed -e 's/%pkgname%/gpt/g' -e 's/%version%/0.0.1/g' -e 's/%size%/1024/g' -e 's/%maintainer%/GPT Dev Team/g' -e 's/%description%/gpt/g'  -i ./DEBIAN/control
         cd -
         dpkg-deb --build $PKGDIR
-
-    - name: Install gpt
-      run: |
-        sudo dpkg -i gpt-${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.compiler }}-${{ matrix.mpi }}.deb
 
     - name: Create combined package
       run: |

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -415,41 +415,47 @@ jobs:
     - name: Run tests
       if: matrix.mpi == 'none'
       run: |
-        cd gpt/tests
+        cd gpt
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
-        ./run "coverage run"
+        ./tests/run "coverage run"
 
     - name: Run tests
       if: matrix.mpi == 'openmpi'
       env:
         LD_PRELOAD: libmpi.so
       run: |
-        cd gpt/tests
+        cd gpt
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
-        mpirun -np 2 -mca btl ^openib -bind-to core python core/scalar.py --mpi 1.1.1.2
-        ./run "mpirun -np 1 -mca btl ^openib coverage run"
-        ./run "mpirun -np 2 -bind-to core -mca btl ^openib coverage run --parallel-mode" "--mpi 1.1.1.2 --mpi 1.1.2"
-        coverage combine
+        mpirun -np 2 -mca btl ^openib -bind-to core python tests/core/scalar.py --mpi 1.1.1.2
+        ./tests/run "mpirun -np 1 -mca btl ^openib coverage run"
+        ./tests/run "mpirun -np 2 -bind-to core -mca btl ^openib coverage run" "--mpi 1.1.1.2 --mpi 1.1.2"
 
     - name: Run tests
       if: matrix.mpi == 'mpich'
       run: |
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
-        cd gpt/tests
-        ./run "mpirun -np 1 coverage run"
-        ./run "mpirun -np 2 -bind-to core coverage run --parallel-mode" "--mpi 1.1.1.2 --mpi 1.1.2"
-        coverage combine
+        cd gpt
+        ./tests/run "mpirun -np 1 coverage run"
+        ./tests/run "mpirun -np 2 -bind-to core coverage run" "--mpi 1.1.1.2 --mpi 1.1.2"
 
     - name: Coverage report
       run: |
-        cd gpt/tests
+        cd gpt
+        coverage combine
         ls -lha
-        coverage report -m
+        coverage report -m  # Print coverage report to screen
+        coverage xml  # Export coverage report as XML file, for codecov.io
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./gpt/tests/.coverage
+      env:
+        PYTHON_VERSION: python${{ matrix.python-version }}
+        COMPILER: ${{ matrix.compiler }}
+        MPI: ${{ matrix.mpi }}
+        CODECOV_ENV: PYTHON_VERSION,COMPILER,MPI
+      run: |
+        cd gpt
+        bash <(curl -s https://codecov.io/bash) \
+          -f ./coverage.xml
 
 
   build-gpt-doc:

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -396,7 +396,7 @@ jobs:
 
     - name: Setup python dependencies
       run: |
-        pip install numpy
+        pip install numpy coverage
 
     - name: Download prebuild python-gpt
       uses: actions/download-artifact@v2
@@ -417,7 +417,8 @@ jobs:
       run: |
         cd gpt/tests
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
-        ./run
+        ./run "coverage run"
+        coverage report -m
 
     - name: Run tests
       if: matrix.mpi == 'openmpi'
@@ -427,16 +428,18 @@ jobs:
         cd gpt/tests
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
         mpirun -np 2 -mca btl ^openib -bind-to core python core/scalar.py --mpi 1.1.1.2
-        ./run "mpirun -np 1 -mca btl ^openib python"
-        ./run "mpirun -np 2 -bind-to core -mca btl ^openib python" "--mpi 1.1.1.2 --mpi 1.1.2"
+        ./run "coverage run mpirun -np 1 -mca btl ^openib python"
+        ./run "coverage run mpirun -np 2 -bind-to core -mca btl ^openib python" "--mpi 1.1.1.2 --mpi 1.1.2"
+        coverage report -m
 
     - name: Run tests
       if: matrix.mpi == 'mpich'
       run: |
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
         cd gpt/tests
-        ./run "mpirun -np 1 python"
-        ./run "mpirun -np 2 -bind-to core python" "--mpi 1.1.1.2 --mpi 1.1.2"
+        ./run "coverage run mpirun -np 1 python"
+        ./run "coverage run mpirun -np 2 -bind-to core python" "--mpi 1.1.1.2 --mpi 1.1.2"
+        coverage report -m
 
 
   build-gpt-doc:

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -418,7 +418,6 @@ jobs:
         cd gpt/tests
         export PYTHONPATH=/usr/local/lib/python${{ matrix.python-version}}/site-packages:/usr/local/lib64/python${{ matrix.python-version}}/site-packages
         ./run "coverage run"
-        coverage report -m
 
     - name: Run tests
       if: matrix.mpi == 'openmpi'
@@ -430,7 +429,7 @@ jobs:
         mpirun -np 2 -mca btl ^openib -bind-to core python core/scalar.py --mpi 1.1.1.2
         ./run "mpirun -np 1 -mca btl ^openib coverage run"
         ./run "mpirun -np 2 -bind-to core -mca btl ^openib coverage run --parallel-mode" "--mpi 1.1.1.2 --mpi 1.1.2"
-        coverage report -m
+        coverage combine
 
     - name: Run tests
       if: matrix.mpi == 'mpich'
@@ -439,6 +438,12 @@ jobs:
         cd gpt/tests
         ./run "mpirun -np 1 coverage run"
         ./run "mpirun -np 2 -bind-to core coverage run --parallel-mode" "--mpi 1.1.1.2 --mpi 1.1.2"
+        coverage combine
+
+    - name: Coverage report
+      run: |
+        cd gpt/tests
+        ls -lha
         coverage report -m
 
 

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -446,6 +446,11 @@ jobs:
         ls -lha
         coverage report -m
 
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./gpt/tests/.coverage
+
 
   build-gpt-doc:
     needs: [build-grid, build-gpt]

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ missing
 /lib/gpt/pyfiles.inc
 /lib/cgpt/ccfiles.inc
 /lib/cgpt/hfiles.inc
+*.coverage*
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build/Test](https://github.com/lehner/gpt/workflows/Build/Test/badge.svg)](https://github.com/lehner/gpt/actions?query=workflow%3ABuild%2FTest)
+[![codecov](https://codecov.io/gh/lehner/gpt/branch/master/graph/badge.svg)](https://codecov.io/gh/lehner/gpt)
 
 ![GPT Logo](/documentation/logo/logo-1280-640.png)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-fixes:
-  - "/usr/local/lib/python3.*/site-packages/::lib/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "/usr/local/lib/python3.*/site-packages/::lib/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[coverage:run]
+parallel = True
+
+[coverage:paths]
+source =
+    lib/
+    /usr/local/lib/python*/site-packages
+
+[coverage:report]
+sort = Cover

--- a/tests/run
+++ b/tests/run
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 runner=$1
 extra=$2
 fail=0
@@ -9,26 +10,27 @@ fi
 
 LOG=$(mktemp)
 fail_list=""
+test_path=${BASH_SOURCE%/*}
 
 for f in \
-    core/core.py \
-    core/tensors.py \
-    core/gamma.py \
-    core/block.py \
-    core/scalar.py \
-    core/checksums.py \
-    core/importexport.py \
-    core/orthogonalize.py \
-    core/matrix.py \
-    core/split.py \
-    core/other_reps.py \
-    random/random-simple.py \
-    qcd/a2a.py \
-    qcd/fermion-operators.py \
-    qcd/sap.py \
-    algorithms/implicitly-restarted-lanczos.py \
-    algorithms/arnoldi.py \
-    algorithms/solvers.py
+    ${test_path}/core/core.py \
+    ${test_path}/core/tensors.py \
+    ${test_path}/core/gamma.py \
+    ${test_path}/core/block.py \
+    ${test_path}/core/scalar.py \
+    ${test_path}/core/checksums.py \
+    ${test_path}/core/importexport.py \
+    ${test_path}/core/orthogonalize.py \
+    ${test_path}/core/matrix.py \
+    ${test_path}/core/split.py \
+    ${test_path}/core/other_reps.py \
+    ${test_path}/random/random-simple.py \
+    ${test_path}/qcd/a2a.py \
+    ${test_path}/qcd/fermion-operators.py \
+    ${test_path}/qcd/sap.py \
+    ${test_path}/algorithms/implicitly-restarted-lanczos.py \
+    ${test_path}/algorithms/arnoldi.py \
+    ${test_path}/algorithms/solvers.py
 do
 
 printf "%-60s" " [TEST] $f"


### PR DESCRIPTION
Add a coverage report of the ran tests to the Github actions, can either be viewed in the gh-actions logs or on codecov, see for example here:
https://codecov.io/gh/aragon999/gpt/tree/43cb8b7d44b3b43a50451b7ce5b995fc64b0a76a

I am not sure what happens if one has not registered on the codecov page, but we probably will see soon :-) 
(after the Github action jobs of this PR are finished). 

Maybe it will automatically appear here: https://codecov.io/gh/lehner/gpt/

Until now I was not able to produce an output which also shows the not ran files, but I manually checked, currently there are none (except for some tests). Also I am not sure if the `tests` folder should be excluded entirely from the coverage report.

To locally run the coverage tool it should be sufficient to run the following commands:
```bash
# Run some tests where we want to have the report of
$ mpirun -np 2 -bind-to core coverage run tests/core/scalar.py --mpi 1.1.1.2 --mpi 1.1.2
# Combine reports (as there are multiple generated from the parallel run)
$ coverage combine
$ coverage report -m
```

I also added a badge, which should appear as
 [![codecov](https://codecov.io/gh/aragon999/gpt/branch/feature/code-coverage/graph/badge.svg)](https://codecov.io/gh/aragon999/gpt/branch/feature/code-coverage)
after the first coverage reports are submitted.
