### PR TITLE
Move flake8 config to setup.cfg

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           flake8 \
             --format="::error file=%(path)s,line=%(row)s,col=%(col)s::%(code)s:%(text)s" \
-            --ignore="E203,E401,E501,W503,F401,F403,F405,E741,E302" \
-            --max-line-length=100 lib/gpt > tmp_flake.log || true
+            lib/gpt > tmp_flake.log || true
 
           cat tmp_flake.log

--- a/scripts/black
+++ b/scripts/black
@@ -9,9 +9,7 @@ for f in ${FILES}
 do
 
 python3 -m black -t py36 ${f}
-python3 -m flake8 \
-    --ignore=E203,E401,E501,W503,F401,F403,F405,E741,E302 \
-    --max-line-length=100 ${f}
+python3 -m flake8 ${f}
 if [[ "$?" != "0" ]];
 then
     echo "Need to fix $f"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,7 @@ source =
 
 [coverage:report]
 sort = Cover
+
+[flake8]
+ignore = E203,E401,E501,W503,F401,F403,F405,E741,E302
+max-line-length = 100


### PR DESCRIPTION
This will make it easier in the future to adjust the flake configuration, if needed.

Furthermore one can now also run `flake8` from the root repo directory, without any command line arguments:
```
flake8 lib/gpt
```