### PR TITLE
Do not use autotools default CXXFLAGS resolves #45

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,14 +21,15 @@ AM_INIT_AUTOMAKE([1.15.1 foreign subdir-objects -Wall])
 # separate directory for m4 stuff (libtools prefers this)
 AC_CONFIG_MACRO_DIR([m4])
 
+# Trick to set empty default value for CXXFLAGS, needs to be set before
+# running AC_PROG_CXX
+: ${CXXFLAGS=""}
+
 # C++ -Compiler
 AC_PROG_CXX
 
 # use configure header
 AC_CONFIG_HEADERS([config.h])
-
-# Trick to set empty default value for CXXFLAGS
-: ${CXXFLAGS=""}
 
 # archiver (Automake needs this for libraries)
 AM_PROG_AR


### PR DESCRIPTION
According to the autoconf documentation the [`AC_PROG_CXX`](https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/C_002b_002b-Compiler.html) adds the default flags
`-g -O2` if no other flags are given:
https://github.com/lehner/gpt/blob/104132f949b2f3face3bd0ea52ffb68bd125cf80/configure.ac#L25

> If using the GNU C++ compiler, set shell variable GXX to ‘yes’. If output variable CXXFLAGS was not already set, set it to -g -O2 for the GNU C++ compiler (-O2 on systems where G++ does not accept -g), or -g for other compilers. 

This pull request should ensure that no default autoconf `CXXFLAGS` are set.
See here: https://github.com/aragon999/gpt/runs/905816015?check_suite_focus=true

I additionally noticed, that `CFLAGS` is also set to
```
CFLAGS = -g -O2
```

As far as I can see, this should make no difference so I leave it for now.

This pull request resolves #45 