### PR TITLE
Include Grid version hash in cgpt version cache hash

### DIFF
--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -243,6 +243,7 @@ jobs:
         echo ${{ hashFiles('gpt/configure.ac') }} >> cgpt_cache_key_file
         echo ${{ hashFiles('gpt/Makefile.am') }} >> cgpt_cache_key_file
         echo ${{ hashFiles('gpt/cgpt/Makefile.am') }} >> cgpt_cache_key_file
+        echo ${{ needs.build-grid.outputs.grid-version }} >> cgpt_cache_key_file
 
         echo "::set-output name=key::$(sha256sum cgpt_cache_key_file|cut -f 1 -d " ")-${CACHE_KEY}"
 


### PR DESCRIPTION
The cgpt.so is not recompiled, if Grid is recompiled, this should work automatically from now on.