### PR TITLE
Feature/test help message

### DIFF
--- a/tests/run
+++ b/tests/run
@@ -21,6 +21,9 @@ mkdir -p ${WORK_DIR}
 
 echo "Working directory = ${WORK_DIR}"
 
+echo "Testing help message"
+${runner} -m gpt ${extra} --help
+
 for f in \
     ${test_path}/core/core.py \
     ${test_path}/core/tensors.py \

--- a/tests/run
+++ b/tests/run
@@ -22,7 +22,7 @@ mkdir -p ${WORK_DIR}
 echo "Working directory = ${WORK_DIR}"
 
 echo "Testing help message"
-${runner} -m gpt ${extra} --help
+${runner} ${test_path}/core/core.py ${extra} --help
 
 for f in \
     ${test_path}/core/core.py \


### PR DESCRIPTION
I included a test of the help message in the test-`run` script.
Is it fine in this way, or do we want to check some output? 

I also improved the handling when calling the `--help` with more than one rank, I needed to use the MPI variables set by the MPI wrapper, since MPI is not initialized at that point. Not sure if this is the best way to handle this. 