### PR TITLE
Change link to coverage report to only show master commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build/Test](https://github.com/lehner/gpt/workflows/Build/Test/badge.svg)](https://github.com/lehner/gpt/actions?query=workflow%3ABuild%2FTest)
-[![codecov](https://codecov.io/gh/lehner/gpt/branch/master/graph/badge.svg)](https://codecov.io/gh/lehner/gpt)
+[![codecov](https://codecov.io/gh/lehner/gpt/branch/master/graph/badge.svg)](https://codecov.io/gh/lehner/gpt/branch/master)
 
 ![GPT Logo](/documentation/logo/logo-1280-640.png)
 


### PR DESCRIPTION
I just looked into the issue, that the coverage badge shows the coverage of the latest pull request. 

Unfortunately this seems to be a bug, which is currently investigated (and we need to wait for a fix):
https://community.codecov.io/t/codecov-badge-reports-coverage-percentage-from-merge-request-instead-of-master-branch/1659

Nevertheless I think the URL behind the badge should only show commits from the master branch. This is what this PR does.