### PR TITLE
Feature/docker images

### DIFF
--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -506,9 +506,8 @@ jobs:
       - name: Check for rebuild
         id: check-build
         run: |
-          # TODO: Change github.ref before merging to master branch
           if [ "${{ secrets.DOCKER_USERNAME }}" != "" ] && [ "${{ secrets.DOCKER_PASSWORD }}" != "" ] \
-            && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/feature/docker-images" ]
+            && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/master" ]
           then
             echo ::set-output name=should-build::'true'
           else
@@ -546,7 +545,6 @@ jobs:
       - name: Check for rebuild
         id: check-build
         run: |
-          # TODO: Change github.ref before merging to master branch
           if [ "${{ secrets.DOCKER_USERNAME }}" != "" ] && [ "${{ secrets.DOCKER_PASSWORD }}" != "" ] \
             && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/master" ]
           then

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -497,3 +497,99 @@ jobs:
       with:
         name: documentation
         path: gpt/documentation/build
+
+  build-gpt-docker-base:
+    needs: [build-grid, build-gpt, test-gpt]
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check for rebuild
+        id: check-build
+        run: |
+          # TODO: Change github.ref before merging to master branch
+          if [ "${{ secrets.DOCKER_USERNAME }}" != "" ] && [ "${{ secrets.DOCKER_PASSWORD }}" != "" ] \
+            && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/feature/docker-images" ]
+          then
+            echo ::set-output name=should-build::'true'
+          else
+            echo "No Docker credentials found, skipping."
+          fi
+
+      - name: Clone gpt
+        if: ${{ steps.check-build.outputs.should-build }}
+        uses: actions/checkout@v2
+
+      - name: Build docker gpt/base image
+        if: ${{ steps.check-build.outputs.should-build }}
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ secrets.DOCKER_USERNAME }}/gpt-base
+          tags: latest
+          push: true
+          path: docker/base
+
+
+  build-gpt-docker:
+    needs: [build-grid, build-gpt, test-gpt, build-gpt-docker-base]
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: ['gcc', 'clang']
+        # TODO: add other mpi flavors: 'mpich', 'openmpi'
+        mpi: ['none']
+
+    steps:
+      - name: Check for rebuild
+        id: check-build
+        run: |
+          # TODO: Change github.ref before merging to master branch
+          if [ "${{ secrets.DOCKER_USERNAME }}" != "" ] && [ "${{ secrets.DOCKER_PASSWORD }}" != "" ] \
+            && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/feature/docker-images" ]
+          then
+            echo ::set-output name=should-build::'true'
+          else
+            echo "No Docker credentials found, skipping."
+          fi
+
+      - name: Clone gpt
+        if: ${{ steps.check-build.outputs.should-build }}
+        uses: actions/checkout@v2
+
+      - name: Download prebuild python-gpt
+        if: ${{ steps.check-build.outputs.should-build }}
+        uses: actions/download-artifact@v2
+        with:
+          name: python-gpt-${{ runner.os }}-python-3.8-${{ matrix.compiler }}-${{ matrix.mpi }}-${{ needs.build-gpt.outputs.python-gpt-version }}
+
+      - name: Move python-gpt package to docker folder
+        if: ${{ steps.check-build.outputs.should-build }}
+        run: |
+          mv python-gpt-${{ runner.os }}-python-3.8-${{ matrix.compiler }}-${{ matrix.mpi }}.deb docker/play/gpt-packages
+
+      - name: Build docker gpt/play image
+        if: ${{ steps.check-build.outputs.should-build }}
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ secrets.DOCKER_USERNAME }}/gpt-play
+          build_args: BASE_IMAGE=${{ secrets.DOCKER_USERNAME }}/gpt-base,COMPILER=${{ matrix.compiler }},MPI=${{ matrix.mpi }}
+          tags: ${{ matrix.compiler }}-${{ matrix.mpi }}
+          push: true
+          path: docker/play
+
+      - name: Build docker gpt/notebook image
+        if: ${{ steps.check-build.outputs.should-build }}
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ secrets.DOCKER_USERNAME }}/gpt-notebook
+          build_args: BASE_IMAGE=${{ secrets.DOCKER_USERNAME }}/gpt-play,COMPILER=${{ matrix.compiler }},MPI=${{ matrix.mpi }}
+          tags: ${{ matrix.compiler }}-${{ matrix.mpi }}
+          push: true
+          path: docker/notebook

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -282,7 +282,7 @@ jobs:
         ./bootstrap.sh
         mkdir -p build
         cd build
-        ../configure --disable-gpt || cat config.log
+        CXX="$(grid-config --cxx)" ../configure --disable-gpt || cat config.log
         make ${MAKE_BUILD_FLAGS}
         DESTDIR=$PKGDIR make install
 

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -591,6 +591,7 @@ jobs:
           tags: ${{ steps.get-docker-tags.outputs.tags }}
           push: true
           path: docker/play
+          always_pull: true
 
       - name: Build docker gpt/notebook image
         if: ${{ steps.check-build.outputs.should-build }}
@@ -603,3 +604,4 @@ jobs:
           tags: ${{ steps.get-docker-tags.outputs.tags }}
           push: true
           path: docker/notebook
+          always_pull: true

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -512,7 +512,7 @@ jobs:
           then
             echo ::set-output name=should-build::'true'
           else
-            echo "No Docker credentials found, skipping."
+            echo "Skipping docker build."
           fi
 
       - name: Clone gpt
@@ -525,7 +525,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ secrets.DOCKER_USERNAME }}/gpt-base
+          repository: ${{ secrets.DOCKER_USERNAME }}/base
           tags: latest
           push: true
           path: docker/base
@@ -548,11 +548,11 @@ jobs:
         run: |
           # TODO: Change github.ref before merging to master branch
           if [ "${{ secrets.DOCKER_USERNAME }}" != "" ] && [ "${{ secrets.DOCKER_PASSWORD }}" != "" ] \
-            && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/feature/docker-images" ]
+            && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/master" ]
           then
             echo ::set-output name=should-build::'true'
           else
-            echo "No Docker credentials found, skipping."
+            echo "Skipping docker build."
           fi
 
       - name: Clone gpt
@@ -586,8 +586,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ secrets.DOCKER_USERNAME }}/gpt-play
-          build_args: BASE_IMAGE=${{ secrets.DOCKER_USERNAME }}/gpt-base,COMPILER=${{ matrix.compiler }},MPI=${{ matrix.mpi }}
+          repository: ${{ secrets.DOCKER_USERNAME }}/play
+          build_args: BASE_IMAGE=${{ secrets.DOCKER_USERNAME }}/base,COMPILER=${{ matrix.compiler }},MPI=${{ matrix.mpi }}
           tags: ${{ steps.get-docker-tags.outputs.tags }}
           push: true
           path: docker/play
@@ -599,8 +599,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ secrets.DOCKER_USERNAME }}/gpt-notebook
-          build_args: BASE_IMAGE=${{ secrets.DOCKER_USERNAME }}/gpt-play,COMPILER=${{ matrix.compiler }},MPI=${{ matrix.mpi }}
+          repository: ${{ secrets.DOCKER_USERNAME }}/notebook
+          build_args: BASE_IMAGE=${{ secrets.DOCKER_USERNAME }}/play,COMPILER=${{ matrix.compiler }},MPI=${{ matrix.mpi }}
           tags: ${{ steps.get-docker-tags.outputs.tags }}
           push: true
           path: docker/notebook

--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -570,6 +570,16 @@ jobs:
         run: |
           mv python-gpt-${{ runner.os }}-python-3.8-${{ matrix.compiler }}-${{ matrix.mpi }}.deb docker/play/gpt-packages
 
+      - name: Get Tags
+        if: ${{ steps.check-build.outputs.should-build }}
+        id: get-docker-tags
+        run: |
+          tags="${{ matrix.compiler }}-${{ matrix.mpi }}"
+          [ "${{ matrix.compiler }}-${{ matrix.mpi }}" == "clang-none" ] && tags="${tags},latest"
+
+          echo "Image Tags: ${tags}"
+          echo "::set-output name=tags::${tags}"
+
       - name: Build docker gpt/play image
         if: ${{ steps.check-build.outputs.should-build }}
         uses: docker/build-push-action@v1
@@ -578,7 +588,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: ${{ secrets.DOCKER_USERNAME }}/gpt-play
           build_args: BASE_IMAGE=${{ secrets.DOCKER_USERNAME }}/gpt-base,COMPILER=${{ matrix.compiler }},MPI=${{ matrix.mpi }}
-          tags: ${{ matrix.compiler }}-${{ matrix.mpi }}
+          tags: ${{ steps.get-docker-tags.outputs.tags }}
           push: true
           path: docker/play
 
@@ -590,6 +600,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: ${{ secrets.DOCKER_USERNAME }}/gpt-notebook
           build_args: BASE_IMAGE=${{ secrets.DOCKER_USERNAME }}/gpt-play,COMPILER=${{ matrix.compiler }},MPI=${{ matrix.mpi }}
-          tags: ${{ matrix.compiler }}-${{ matrix.mpi }}
+          tags: ${{ steps.get-docker-tags.outputs.tags }}
           push: true
           path: docker/notebook

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ missing
 /lib/cgpt/hfiles.inc
 *.coverage*
 coverage.xml
+/docker/play/gpt-packages/*.deb

--- a/README.md
+++ b/README.md
@@ -11,6 +11,40 @@ GPT is a [Python](https://www.python.org) measurement toolkit built on [Grid](ht
 GPT is developed with the feature/gpt branch of https://github.com/lehner/Grid.
 
 ## Setting up the runtime
+### Docker
+An easy way to quickly test `gpt`, is to use the [prebuild Docker images](https://github.com/lehner/gpt/tree/master/docker).
+
+First make sure you have [Docker](https://docs.docker.com/get-docker/) installed.
+
+To start a Jupyter notebook server with the latest gpt version, execute:
+```
+docker run --rm -p 8888:8888 gptdev/notebook
+```
+
+the server is then bound to the local host system on port `8888`.
+
+To run, for example the [gpt tutorials](https://github.com/lehner/gpt#tutorials), use `-v` to mount the directory into the Docker image, i.e.
+```
+docker run --rm -v /local/path/to/gpt-repository/documentation/tutorial:/notebooks/tutorial -p 8888:8888 gptdev/notebook
+```
+
+Open the shown link `http://127.0.0.1:8888/?token=<token>`, in a browser. You should then see the `tutorial` folder, from within you can run the interactive tutorials.
+
+If you prefer an interactive python3 console run
+```
+docker run --rm -it -p 8888:8888 gptdev/play /usr/bin/python3
+```
+
+or to obtain a bash terminal
+```
+docker run --rm -it -p 8888:8888 gptdev/play /bin/bash
+```
+
+Use `-v /local/gpt/code:/gpt-code` to mount your custom code into the Docker container.
+
+For more information refer to the [Docker docs](https://docs.docker.com/get-started/).
+
+### Manual
 ```bash
 source gpt/scripts/source.sh
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,8 +31,10 @@ It is also possible to run the command with `-d` in the backround and view the k
 
 ## Tags
 
-For the `gpt/play` and `gpt/notebook` in addition to the `latest` tag, which points to `clang-none` the following tags are available:
+For the `gptdev/play` and `gptdev/notebook` images, in addition to the `latest` tag, the following tags are available:
 ```
 gcc-none
 clang-none
 ```
+
+If you omit the tags `latest` is used, which points to `clang-none`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,38 @@
+# GPT - Docker images
+
+## Different image types
+
+### Base
+
+This is the base for all gpt Docker images, everything which is shared between all other images, should be included here. This image will probably not useful otherwise.
+
+This image includes the basic tools, these are currently very basic and require some more work, to be really useful, for more information run `gpt` inside the Docker container.
+
+### Play
+
+This image includes a user preinstalled Python 3.8 and gpt setup. You can use the folder `/gpt-code` to include your code you want to run with gpt.
+
+If you are on the host system in the directory where the gpt code is located run:
+```
+docker run -it -v "$(pwd):/gpt-code" gpt/play
+```
+
+### Notebook
+
+If you want to use `gpt` in a Jupyter notebook you should use this image. You can use the folder `/notebooks` to include your current notebooks.
+
+If you are on the host system in the directory where your notebooks are located run:
+```
+docker run -p 8888:8888 -v "$(pwd):/notebooks" gpt/notebook
+```
+
+Connect in the browser to `localhost:8888` and enter the secret key, which should be visible from the console output.
+It is also possible to run the command with `-d` in the backround and view the key with docker `docker logs <container id>`. Where the container can be found either from the output when starting the container or with `docker container ls`.
+
+## Tags
+
+For the `gpt/play` and `gpt/notebook` in addition to the `latest` tag, which points to `clang-none` the following tags are available:
+```
+gcc-none
+clang-none
+```

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:20.04
+
+WORKDIR /app
+
+RUN \
+    apt-get update && \
+    apt-get install --no-install-recommends -y python3.8 python3-pip sudo && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip3 install --no-cache-dir numpy
+
+ENV PATH="/app/bin:${PATH}"

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -9,3 +9,4 @@ RUN \
     pip3 install --no-cache-dir numpy
 
 ENV PATH="/app/bin:${PATH}"
+ENV TZ="Europe/Berlin"

--- a/docker/notebook/Dockerfile
+++ b/docker/notebook/Dockerfile
@@ -1,0 +1,12 @@
+ARG COMPILER=gcc
+ARG MPI=none
+ARG BASE_IMAGE=gptdev/play
+
+FROM ${BASE_IMAGE}:${COMPILER}-${MPI}
+
+RUN sudo pip3 install --no-cache-dir notebook && \
+    sudo mkdir /notebooks && sudo chown gpt:gpt /notebooks
+
+VOLUME /notebooks
+
+CMD ["jupyter", "notebook", "--allow-root", "--port=8888", "--ip='*'", "--no-browser", "--notebook-dir=/notebooks"]

--- a/docker/play/Dockerfile
+++ b/docker/play/Dockerfile
@@ -1,0 +1,36 @@
+ARG BASE_IMAGE=gptdev/base
+
+FROM ${BASE_IMAGE} AS build
+
+ARG COMPILER=gcc
+ARG MPI=none
+
+RUN \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        libfftw3-double3 libfftw3-single3 libomp5-9 libmpfr6 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY gpt-packages/python-gpt-Linux-python-3.8-${COMPILER}-${MPI}.deb /app/
+
+RUN \
+    dpkg -i python-gpt-Linux-python-3.8-${COMPILER}-${MPI}.deb && \
+    rm python-gpt-Linux-python-3.8-${COMPILER}-${MPI}.deb
+
+RUN groupadd -r gpt && \
+    useradd --no-log-init -m -r -g gpt gpt && \
+    adduser gpt sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+FROM scratch
+COPY --from=build / /
+
+WORKDIR /app
+
+USER gpt
+VOLUME /gpt-code
+
+ENV PYTHONPATH="/usr/local/lib/python3.8/site-packages:${PYTHONPATH}"
+ENV PATH="/app/bin:/home/gpt/.local/bin:${PATH}"
+
+CMD ["/bin/bash"]

--- a/docker/play/Dockerfile
+++ b/docker/play/Dockerfile
@@ -5,10 +5,13 @@ FROM ${BASE_IMAGE} AS build
 ARG COMPILER=gcc
 ARG MPI=none
 
+# FIXME: actually we currently do not need the libopenmpi3 dependencies, but
+#        the cgpt.so compiled with clang-9 is linking against libmpi{,_cxx}.so
+#        therefore for now we still need this dependency
 RUN \
     apt-get update && \
-    apt-get install --no-install-recommends -y \
-        libfftw3-double3 libfftw3-single3 libomp5-9 libmpfr6 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+        libfftw3-double3 libfftw3-single3 libomp5-9 libmpfr6 libopenmpi3 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY gpt-packages/python-gpt-Linux-python-3.8-${COMPILER}-${MPI}.deb /app/


### PR DESCRIPTION
As showed today, I started on implementing the Docker images.

For the images without MPI, I can run all tests successfully from the `gpt-play` image using:
`WORK_DIR="$(mktemp -d)" ./run python3 "--mpi_split 1.1.1.1"`

For the MPI images I get some shared memory errors. But have not found the root cause, yet.
Also for the `mpich` MPI implementation you cannot use `mpirun` yet (it is not automatically set), instead `mpirun.mpich` can be used. But I am not really sure if all other environment variables are correct in that case.

Maybe it would also be reasonable to only install the packages needed for the current image. This needs also to be done.

The `gpt`-scripts for "administration" of the images are currently also not really "production ready". If you have any other ideas what would be "good to have" commands let me know. 

Unfortunately I do not really know how much time I will have next week, but I thought I share my current status, for further discussion.

PS: I just also noticed that I have messed up the jupyter setup in the last step. I will fix that, probably next week, this should be no big issue.