### PR TITLE
Remove libopenmpi3 dependency in docker images

### DIFF
--- a/docker/shell/Dockerfile
+++ b/docker/shell/Dockerfile
@@ -5,13 +5,10 @@ FROM ${BASE_IMAGE} AS build
 ARG COMPILER=gcc
 ARG MPI=none
 
-# FIXME: actually we currently do not need the libopenmpi3 dependencies, but
-#        the cgpt.so compiled with clang-9 is linking against libmpi{,_cxx}.so
-#        therefore for now we still need this dependency
 RUN \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-        libfftw3-double3 libfftw3-single3 libomp5-9 libmpfr6 libopenmpi3 && \
+        libfftw3-double3 libfftw3-single3 libomp5-9 libmpfr6 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY gpt-packages/python-gpt-Linux-python-3.8-${COMPILER}-${MPI}.deb /app/


### PR DESCRIPTION
The problem before was, that the package was actually not recompiled with this change:
https://github.com/lehner/gpt/commit/825dc856ad1dbc5edd979e5442750287ab60c64e

Now the clang package is not linked against the MPI libs:

```
gpt@ee32924428f7:/gpt-code$ ldd /usr/local/lib/python3.8/site-packages/cgpt.so 
	linux-vdso.so.1 (0x00007ffecb7ca000)
	libomp.so.5 => /lib/x86_64-linux-gnu/libomp.so.5 (0x00007f56e4596000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f56e458b000)
	libcrypto.so.1.1 => /lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f56e42b5000)
	libfftw3f.so.3 => /lib/x86_64-linux-gnu/libfftw3f.so.3 (0x00007f56e40a5000)
	libfftw3.so.3 => /lib/x86_64-linux-gnu/libfftw3.so.3 (0x00007f56e3e9f000)
	libmpfr.so.6 => /lib/x86_64-linux-gnu/libmpfr.so.6 (0x00007f56e3e1e000)
	libgmp.so.10 => /lib/x86_64-linux-gnu/libgmp.so.10 (0x00007f56e3d98000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f56e3d7c000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f56e3b9b000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f56e3a4c000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f56e385a000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f56e383f000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f56e381a000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f56e3814000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f56ee53b000)
```
