### PR TITLE
Open boundaries

### DIFF
--- a/lib/cgpt/lib/foundation/matrix.h
+++ b/lib/cgpt/lib/foundation/matrix.h
@@ -15,7 +15,7 @@
 
     You should have received a copy of the GNU General Public License along
     with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 021basis_virtual_size-1n_virtual_red01 USA.
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 template<class CComplex,int basis_virtual_size>

--- a/lib/gpt/core/covariant.py
+++ b/lib/gpt/core/covariant.py
@@ -1,6 +1,7 @@
 #
 #    GPT - Grid Python Toolkit
 #    Copyright (C) 2020  Christoph Lehner (christoph.lehner@ur.de, https://github.com/lehner/gpt)
+#    Copyright (C) 2020  Daniel Richtmann (daniel.richtmann@ur.de, https://github.com/lehner/gpt)
 #
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -18,6 +19,22 @@
 #
 import cgpt, gpt, numpy
 from gpt.params import params_convention
+
+
+def apply_open_boundaries(field):
+    if type(field) == list:
+        return [apply_open_boundaries(x) for x in field]
+
+    assert type(field) == gpt.lattice
+    T = field.grid.fdimensions[3]
+    field[:, :, :, 0] = 0.0
+    field[:, :, :, T - 1] = 0.0
+    return field
+    # TODO create plan and cache it
+
+
+def apply_boundaries(field, open_bc=False):
+    return apply_open_boundaries(field) if open_bc is True else field
 
 
 class shift:

--- a/lib/gpt/core/operator/__init__.py
+++ b/lib/gpt/core/operator/__init__.py
@@ -16,7 +16,7 @@
 #    with this program; if not, write to the Free Software Foundation, Inc.,
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from gpt.core.operator.matrix_operator import matrix_operator
+from gpt.core.operator.matrix_operator import matrix_operator, site_diagonal_operator
 from gpt.core.operator.unary import (
     adj,
     inv,

--- a/lib/gpt/core/operator/matrix_operator.py
+++ b/lib/gpt/core/operator/matrix_operator.py
@@ -231,3 +231,45 @@ class matrix_operator(factor):
             return gpt.util.from_list(dst)
 
         return dst
+
+def site_diagonal_operator(M, with_inverse=True):
+    """
+    create a matrix_operator that just multiplies a site-local matrix
+    """
+
+    if type(M.otype) == gpt.ot_matrix_spin:
+        otype = gpt.ot_vector_spin(M.otype.shape[0])
+    elif type(M.otype) == gpt.ot_matrix_color:
+        otype = gpt.ot_vector_color(M.otype.shape[0])
+    elif type(M.otype) == gpt.ot_matrix_spin_color:
+        otype = gpt.ot_vector_spin_color(M.otype.shape[0], M.otype.shape[2])
+    else:
+        assert False
+    grid = M.grid
+
+    def mat(dst, src):
+        dst @= M * src
+
+    def adj_mat(dst, src):
+        dst @= gpt.adj(M) * src
+
+    if with_inverse:
+        Minv = gpt.matrix.inv(M)
+
+        def inv_mat(dst, src):
+            dst @= Minv * src
+
+        def adj_inv_mat(dst, src):
+            dst @= gpt.adj(Minv) * src
+    else:
+        inv_mat = None
+        adj_inv_mat = None
+
+    return matrix_operator(
+        mat=mat,
+        adj_mat=adj_mat,
+        inv_mat=inv_mat,
+        adj_inv_mat=adj_inv_mat,
+        otype=otype,
+        grid=grid
+    )

--- a/lib/gpt/core/otype.py
+++ b/lib/gpt/core/otype.py
@@ -157,6 +157,9 @@ class ot_matrix_su3_fundamental(ot_matrix_color):
             "ot_singlet": (lambda: self, None),
         }
 
+    def identity(self):
+        return matrix_color(numpy.identity(self.shape[0]), self.shape[0],)
+
     def generators(self, dt):
         # Generators always need to satisfy normalization Tr(T_a T_b) = 1/2 delta_{ab}
         return [
@@ -194,6 +197,9 @@ class ot_matrix_su2_fundamental(ot_matrix_color):
         self.rmtab = {
             "ot_singlet": (lambda: self, None),
         }
+
+    def identity(self):
+        return matrix_color(numpy.identity(self.shape[0]), self.shape[0],)
 
     def generators(self, dt):
         # The generators are normalized such that T_a^2 = Id/2Nc + d_{aab}T_b/2
@@ -263,6 +269,9 @@ class ot_matrix_spin(ot_base):
         self.rmtab = {
             "ot_singlet": (lambda: self, None),
         }
+
+    def identity(self):
+        return matrix_color(numpy.identity(self.shape[0]), self.shape[0],)
 
 
 def matrix_spin(grid, ndim):

--- a/lib/gpt/core/util.py
+++ b/lib/gpt/core/util.py
@@ -87,3 +87,14 @@ def all_have_attribute(value, a):
     if type(value) == list and len(value) > 0:
         return all([all_have_attribute(v, a) for v in value])
     return hasattr(value, a)
+
+
+# fdimensions
+def fdimensions_from_openqcd(fdim):
+    assert len(fdim) == 4
+    return [int(fdim[(i + 1) % 4]) for i in range(4)]  # X Y Z T <- T X Y Z
+
+
+def fdimensions_to_openqcd(fdim):
+    assert len(fdim) == 4
+    return [int(fdim[(i - 1) % 4]) for i in range(4)]  # T X Y Z <- X Y Z T

--- a/lib/gpt/qcd/fermion/reference/wilson.py
+++ b/lib/gpt/qcd/fermion/reference/wilson.py
@@ -42,6 +42,14 @@ class wilson(shift, matrix_operator):
             parent=self.F_grid.parent,
             mpi=self.F_grid.mpi,
         )
+        self.csw = None
+        for one, other in [("csw_r", "csw_t"), ("csw_t", "csw_r")]:
+            if one in params:
+                assert other in params
+                self.csw = params[one]
+                assert params[other] == self.csw
+        assert "csw" not in params
+
         if "mass" in params:
             assert "kappa" not in params
             self.mass = params["mass"]
@@ -57,8 +65,7 @@ class wilson(shift, matrix_operator):
             self.cF = params["cF"]
             T = self.L[3]
 
-        if "csw" in params:
-            self.csw = params["csw"]
+        if self.csw is not None:
 
             def gamma_product(M, gamma):
                 """
@@ -105,7 +112,6 @@ class wilson(shift, matrix_operator):
             self.Mdiag = site_diagonal_operator(self.clover)
 
         else:
-            self.csw = None
             self.clover = 0.5 / self.kappa
             self.clover_inv = 1.0 / self.clover
 

--- a/lib/gpt/qcd/fermion/reference/wilson.py
+++ b/lib/gpt/qcd/fermion/reference/wilson.py
@@ -22,6 +22,7 @@ from gpt.params import params_convention
 from gpt.core.covariant import shift, apply_boundaries
 from gpt import matrix_operator, site_diagonal_operator
 
+
 class wilson(shift, matrix_operator):
     # M = sum_mu gamma[mu]*D[mu] + m0 - 1/2 sum_mu D^2[mu]
     # m0 + 4 = 1/2/kappa
@@ -34,11 +35,21 @@ class wilson(shift, matrix_operator):
         otype = g.ot_vector_spin_color(4, Nc)
         grid = U[0].grid
         self.F_grid = grid
+        self.F_grid_eo = g.grid(
+            self.F_grid.gdimensions,
+            self.F_grid.precision,
+            g.redblack,
+            parent=self.F_grid.parent,
+            mpi=self.F_grid.mpi,
+        )
         if "mass" in params:
             assert "kappa" not in params
+            self.mass = params["mass"]
             self.kappa = 1.0 / (params["mass"] + 4.0) / 2.0
         else:
+            assert "kappa" in params
             self.kappa = params["kappa"]
+            self.mass = 1 / (2 * params["kappa"]) - 4
 
         self.open_bc = params["boundary_phases"][3] == 0.0
         if self.open_bc:

--- a/lib/gpt/qcd/fermion/reference/wilson.py
+++ b/lib/gpt/qcd/fermion/reference/wilson.py
@@ -199,7 +199,7 @@ class wilson(shift, matrix_operator):
 
     def _M(self, dst, src):
         assert dst != src
-        dst @= self.Meooe * src + self.Mooee * src
+        dst @= self.Dhop * src + self.Mdiag * src
         apply_boundaries(dst, self.open_bc)
 
     def _G5M(self, dst, src):

--- a/lib/gpt/qcd/gauge/__init__.py
+++ b/lib/gpt/qcd/gauge/__init__.py
@@ -18,6 +18,6 @@
 #
 from gpt.qcd.gauge.create import random, unit
 from gpt.qcd.gauge.representation import fundamental_to_adjoint, assert_unitary
-from gpt.qcd.gauge.loops import plaquette
+from gpt.qcd.gauge.loops import plaquette, field_strength
 from gpt.qcd.gauge.transformation import transformed
 import gpt.qcd.gauge.smear

--- a/lib/gpt/qcd/gauge/loops.py
+++ b/lib/gpt/qcd/gauge/loops.py
@@ -37,3 +37,16 @@ def plaquette(U):
                 )
             )
     return 2.0 * tr.real / vol / Nd / (Nd - 1) / ndim
+
+
+def field_strength(U, mu, nu):
+    """ returns field strength tensor \hat{F}_{\mu\nu} """
+
+    assert mu != nu
+    # v = staple_up - staple_down
+    v = g.eval(g.cshift(U[nu], mu, 1) * g.adj(g.cshift(U[mu], nu, 1)) * g.adj(U[nu])
+               - g.cshift(g.adj(g.cshift(U[nu], mu, 1)) * g.adj(U[mu]) * U[nu], nu, -1))
+
+    F = g.eval(U[mu] * v + g.cshift(v * U[mu], mu, -1))
+    F @= 0.125 * (F - g.adj(F))
+    return F

--- a/tests/core/matrix.py
+++ b/tests/core/matrix.py
@@ -56,11 +56,12 @@ for grid, eps in [(grid_dp, 1e-14), (grid_sp, 1e-6)]:
 
 # test inv
 for grid, eps in [(grid_dp, 1e-14), (grid_sp, 1e-6)]:
-    rng = g.random("test")
-    m = rng.cnormal(g.mspincolor(grid))
-    minv = g.matrix.inv(m)
-    eye = g.lattice(m)
-    eye[:] = m.otype.identity()
-    eps2 = g.norm2(m * minv - eye) / (12 * grid.fsites)
-    g.message(f"test M*M^-1 = 1: {eps2}")
-    assert eps2 < eps ** 2
+    for dtype in [g.mcolor, g.mspin, g.mspincolor]:
+        rng = g.random("test")
+        m = rng.cnormal(dtype(grid))
+        minv = g.matrix.inv(m)
+        eye = g.lattice(m)
+        eye[:] = m.otype.identity()
+        eps2 = g.norm2(m * minv - eye) / (12 * grid.fsites)
+        g.message(f"test M*M^-1 = 1 for {m.otype.__name__}: {eps2}")
+        assert eps2 < eps ** 2

--- a/tests/core/matrix.py
+++ b/tests/core/matrix.py
@@ -53,3 +53,14 @@ for grid, eps in [(grid_dp, 1e-14), (grid_sp, 1e-6)]:
             f"Test {op[1].__name__}: {a} == {b} with argument {m[0, 0, 0, 0, 1, 2]}: {eps2}"
         )
         assert eps2 < eps ** 2.0
+
+# test inv
+for grid, eps in [(grid_dp, 1e-14), (grid_sp, 1e-6)]:
+    rng = g.random("test")
+    m = rng.cnormal(g.mspincolor(grid))
+    minv = g.matrix.inv(m)
+    eye = g.lattice(m)
+    eye[:] = m.otype.identity()
+    eps2 = g.norm2(m * minv - eye) / (12 * grid.fsites)
+    g.message(f"test M*M^-1 = 1: {eps2}")
+    assert eps2 < eps ** 2

--- a/tests/qcd/fermion_operators.py
+++ b/tests/qcd/fermion_operators.py
@@ -56,7 +56,7 @@ assert eps < 1e-13
 
 # more thorough test of Grid-based-Wilson vs reference-Wilson
 wc = g.qcd.fermion.wilson_clover(U, p, csw_r=2.0171, csw_t=2.0171)
-wc_ref = g.qcd.fermion.reference.wilson(U, p, csw=2.0171)
+wc_ref = g.qcd.fermion.reference.wilson(U, p, csw_r=2.0171, csw_t=2.0171)
 assert g.norm2(wc * src - wc_ref * src) / g.norm2(wc * src) < 1e-13
 assert g.norm2(wc.Mdiag * src - wc_ref.Mdiag * src) / g.norm2(wc.Mdiag * src) < 1e-13
 assert g.norm2(wc.Dhop * src - wc_ref.Dhop * src) / g.norm2(wc.Dhop * src) < 1e-13

--- a/tests/qcd/fermion_operators.py
+++ b/tests/qcd/fermion_operators.py
@@ -54,6 +54,18 @@ eps = g.norm2(dst - dst_ref) / g.norm2(dst)
 g.message("Test wilson versus reference:", eps)
 assert eps < 1e-13
 
+# more thorough test of Grid-based-Wilson vs reference-Wilson
+wc = g.qcd.fermion.wilson_clover(U, p, csw_r=2.0171, csw_t=2.0171)
+wc_ref = g.qcd.fermion.reference.wilson(U, p, csw=2.0171)
+assert g.norm2(wc * src - wc_ref * src) / g.norm2(wc * src) < 1e-13
+assert g.norm2(wc.Mdiag * src - wc_ref.Mdiag * src) / g.norm2(wc.Mdiag * src) < 1e-13
+assert g.norm2(wc.Dhop * src - wc_ref.Dhop * src) / g.norm2(wc.Dhop * src) < 1e-13
+for mu in range(4):
+    for fb in [1,-1]:
+        assert g.norm2(wc.Mdir(mu, fb) * src - wc_ref.Mdir(mu, fb) * src) / g.norm2(wc.Mdir(mu, fb) * src) < 1e-13
+del wc
+del wc_ref
+
 # now timing
 t0 = g.time()
 for i in range(100):

--- a/tests/qcd/open_boundaries.py
+++ b/tests/qcd/open_boundaries.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#
+# Authors: Daniel Richtmann 2020
+#          Christoph Lehner 2020
+#
+# Desc.: Test open boundary conditions
+#
+import gpt as g
+import numpy as np
+import sys
+
+# setup rng, mute
+g.default.set_verbose("random", False)
+rng = g.random("open_boundaries")
+
+# load configuration
+U = g.qcd.gauge.random(g.grid([8, 8, 8, 16], g.double), rng)
+# U = g.load("/home/rid04246/d2/configs/openqcd/test_16x8n110")
+g.message("Plaquette:", g.qcd.gauge.plaquette(U))
+
+# quark
+# w = g.qcd.fermion.wilson_clover(
+w = g.qcd.fermion.reference.wilson(
+    U,
+    {
+        "kappa": 0.11,
+        "csw_r": 1.5,
+        "csw_t": 1.5,
+        "csw": 1.5,  # reference uses this instead
+        "xi_0": 1,
+        "nu": 1,
+        "isAnisotropic": False,
+        "boundary_phases": [1.0, 1.0, 1.0, 0.0],
+        "cF": 1.3,
+    },
+)
+
+# default grid
+grid = U[0].grid
+
+# create point source, destination
+src, dst = g.mspincolor(grid), g.mspincolor(grid)
+g.create.point(src, [0, 0, 0, 2])
+
+# abbreviations
+i = g.algorithms.inverter
+p = g.qcd.fermion.preconditioner
+
+# build solver
+cg = i.cg({"eps": 1e-12, "maxiter": 1000})
+fgmres = i.fgmres({"eps": 1e-12, "maxiter": 1000})
+# slv = i.preconditioned(p.eo2_ne(parity=g.odd), cg) # not cg because Mdag not in reference
+slv = fgmres
+
+# calculate propagator
+w.propagator(slv, dst, src)
+
+# two point
+corr_2pt = g.slice(g.trace(dst * g.adj(dst)), 3)
+
+# reference
+corr_2pt_ref = [
+    0.0,
+    0.02400406370732104,
+    0.6937893453940418,
+    0.029038375810865238,
+    0.0031216024320516755,
+    0.0004785714579322768,
+    0.00010094651736288815,
+    2.647433330942393e-05,
+    7.71992079324806e-06,
+    2.3878280342528085e-06,
+    7.66326124044683e-07,
+    2.5018245407518893e-07,
+    8.277640242454872e-08,
+    2.7352263656657104e-08,
+    6.4311303478774405e-09,
+    0.0,
+]
+# corr_2pt_ref = [  # the one for test_16x8n110 from chroma
+#     0.0,
+#     0.0232014984431081,
+#     0.760212289593613,
+#     0.0250445220762833,
+#     0.00164287923647052,
+#     0.000113657795962742,
+#     7.85943713182201e-06,
+#     4.92789424316055e-07,
+#     3.08721069096737e-08,
+#     1.95085023880033e-09,
+#     1.15143939616122e-10,
+#     7.78273259347072e-12,
+#     4.88365539089639e-13,
+#     3.25681805328975e-14,
+#     1.72080431810457e-15,
+#     0.0,
+# ]
+
+# output
+eps = 0.0
+for t in range(len(corr_2pt_ref)):
+    eps += (corr_2pt[t].real - corr_2pt_ref[t]) ** 2.0
+    g.message(f"corr: {t} {corr_2pt[t].real} {corr_2pt_ref[t]}")
+eps = eps ** 0.5 / len(corr_2pt_ref)
+g.message(f"eps: {eps}")
+assert eps <= 1e-15
+g.message("Test successful")

--- a/tests/qcd/open_boundaries.py
+++ b/tests/qcd/open_boundaries.py
@@ -52,7 +52,7 @@ fgmres = i.fgmres({"eps": 1e-12, "maxiter": 1000})
 slv = fgmres
 
 # calculate propagator
-w.propagator(slv, dst, src)
+dst @= w.propagator(slv) * src
 
 # two point
 corr_2pt = g.slice(g.trace(dst * g.adj(dst)), 3)

--- a/tests/qcd/open_boundaries.py
+++ b/tests/qcd/open_boundaries.py
@@ -26,7 +26,6 @@ w = g.qcd.fermion.reference.wilson(
         "kappa": 0.11,
         "csw_r": 1.5,
         "csw_t": 1.5,
-        "csw": 1.5,  # reference uses this instead
         "xi_0": 1,
         "nu": 1,
         "isAnisotropic": False,

--- a/tests/qcd/openqcd_dslash.py
+++ b/tests/qcd/openqcd_dslash.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#
+# Authors: Daniel Richtmann 2020
+#          Mattia Bruno     2020
+#
+# Load openqcd fields, apply open bc dslash, compare results
+#
+import os
+import gpt as g
+import numpy as np
+
+# helper functions
+def read_sfld(fname):
+    """
+    Read a spinor field written by openqcd into a numpy array.
+    Function was written by Mattia Bruno.
+    """
+    with open(fname, "rb") as f:
+        b = f.read(4 * 5)
+        tmp = np.frombuffer(b, dtype=np.int32)
+        lat = tmp[0:4]
+        assert tmp[4] == 0
+
+        b = f.read(8)
+        norm = np.frombuffer(b, dtype=np.float64)
+
+        vol = np.prod(lat)
+        b = f.read(vol * 12 * 2 * 8)
+
+        fld = np.frombuffer(b, dtype=np.float64)
+        fld = np.reshape(fld, tuple(lat) + (12, 2))
+
+        print(f"Check norm difference = {abs(np.sum(fld**2)-norm)}")
+
+        fld = np.reshape(
+            fld[:, :, :, :, :, 0] + 1j * fld[:, :, :, :, :, 1], tuple(lat) + (4, 3)
+        )
+    return lat, norm, fld
+
+
+def read_openqcd_fermion(fname):
+    """
+    Read a spinor field written by openqcd into a vspincolor object.
+    """
+    # read into numpy array
+    lat, norm, fld = read_sfld(fname)
+
+    # convert numpy to gpt field
+    field = g.vspincolor(g.grid(g.util.fdimensions_from_openqcd(lat), g.double))
+    field[:] = 0.0
+    X, Y, Z, T = field.grid.fdimensions
+    for t in range(T):
+        for x in range(X):
+            for y in range(Y):
+                for z in range(Z):
+                    field[x, y, z, t] = g.vspincolor(fld[t, x, y, z])
+
+    # sanity check
+    norm_gpt = g.norm2(field)
+    diff = abs(norm[0] - norm_gpt)
+    eps = (diff / norm[0]) ** 0.5
+    g.message(f"Norms: file = {norm[0]}, gpt = {norm_gpt}, diff = {diff}, eps = {eps}")
+    assert eps < 1e-15
+
+    return field
+
+
+# workdir
+if "WORK_DIR" in os.environ:
+    work_dir = os.environ["WORK_DIR"]
+else:
+    work_dir = "."
+
+# request test files
+for f in ["field_gauge.bin", "field_src.bin", "field_dst.bin"]:
+    g.repository.load(f"{work_dir}/{f}", f"gpt://tests/qcd/openqcd_dslash/{f}")
+
+# load fields from files
+U = g.load(f"{work_dir}/field_gauge.bin")
+src = read_openqcd_fermion(f"{work_dir}/field_src.bin")
+dst_oqcd = read_openqcd_fermion(f"{work_dir}/field_dst.bin")
+
+# fermion operator
+w = g.qcd.fermion.reference.wilson(
+    U,
+    {
+        "kappa": 0.13500,
+        "csw_r": 1.978,
+        "csw_t": 1.978,
+        "csw": 1.978,  # reference implementation uses this
+        "cF": 1.3,
+        "xi_0": 1,
+        "nu": 1,
+        "isAnisotropic": False,
+        "boundary_phases": [1.0, 1.0, 1.0, 0.0],  # this triggers open bc
+    },
+)
+
+# apply gpt operator (openqcd uses different representation)
+dst_gpt = g(g.gamma[1] * w.M * g.gamma[1] * src)
+
+# report error
+eps = (g.norm2(dst_gpt - dst_oqcd) / g.norm2(dst_oqcd)) ** 0.5
+g.message(
+    f"Test for matching operators {'passed' if eps <= 1e-15 else 'failed'}. eps = {eps}, tol = {1e-15}"
+)
+assert eps <= 1e-15

--- a/tests/qcd/openqcd_dslash.py
+++ b/tests/qcd/openqcd_dslash.py
@@ -87,7 +87,6 @@ w = g.qcd.fermion.reference.wilson(
         "kappa": 0.13500,
         "csw_r": 1.978,
         "csw_t": 1.978,
-        "csw": 1.978,  # reference implementation uses this
         "cF": 1.3,
         "xi_0": 1,
         "nu": 1,

--- a/tests/run
+++ b/tests/run
@@ -45,6 +45,7 @@ for f in \
     ${test_path}/qcd/gauge.py \
     ${test_path}/qcd/domain_wall.py \
     ${test_path}/qcd/sap.py \
+    ${test_path}/qcd/open_boundaries.py \
     ${test_path}/algorithms/implicitly_restarted_lanczos.py \
     ${test_path}/algorithms/arnoldi.py \
     ${test_path}/algorithms/solvers.py \

--- a/tests/run
+++ b/tests/run
@@ -46,6 +46,7 @@ for f in \
     ${test_path}/qcd/domain_wall.py \
     ${test_path}/qcd/sap.py \
     ${test_path}/qcd/open_boundaries.py \
+    ${test_path}/qcd/openqcd_dslash.py \
     ${test_path}/algorithms/implicitly_restarted_lanczos.py \
     ${test_path}/algorithms/arnoldi.py \
     ${test_path}/algorithms/solvers.py \


### PR DESCRIPTION
Adds open boundaries on top of @krox's PR (I rebased his work onto the current master).

Checks contained in this PR:
- Comparison with openqcd:
  I coded up a binary to apply openqcd's dirac operator with `bc=0` and write the input and output fields to disk, see [here](https://github.com/DanielRichtmann/openqcd/blob/compare/gpt/devel/dirac/compare_gpt.c).
  I then read in these files in `tests/qcd/openqcd_dslash.py`, applied our dirac operator, and compared.
  Locally I found agreement up to `1.9e-16` in double precision.
- Comparison with chroma:
  Based on this [regression test xml ](https://rqcd.ur.de:8443/regensburg-lattice/chroma/-/blob/master/tests/chroma/hadron/propagator/clover-openbc.ini.xml) from rcqd chroma, I ran both chroma and gpt (`tests/qcd/open_boundaries.py`) with open boundaries on a small test configuration and compared the 2 point correlators they produced. I saw agreement up to `1.5e-16` in double precision. I then defined this state in gpt as "correct", changed the test to work on a random gauge field calculated on the fly and use the correlator calculated on this gauge field as the reference for the regression test. For further details see the email chain.

This PR requires [this PR](https://github.com/lehner/gpt-repository/pull/1) in gpt-repository to be merged, since I added the fields produced by the openqcd binary there.