### PR TITLE
Replace set-env with environment file in Github Actions

### DIFF
--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -51,8 +51,8 @@ jobs:
     - name: Set compiler to cc and c++
       if: matrix.mpi == 'none'
       run: |
-        echo '::set-env name=CC::cc'
-        echo '::set-env name=CXX::c++'
+        echo 'CC=cc' >> $GITHUB_ENV
+        echo 'CXX=c++' >> $GITHUB_ENV
 
     - name: Set MPI alternatives to mpich
       if: matrix.mpi == 'mpich'


### PR DESCRIPTION
Just a minor change, for more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/