### PR TITLE
Fix checking against bit masks

### DIFF
--- a/lib/cgpt/lib/expression/linear_combination_implementation.h
+++ b/lib/cgpt/lib/expression/linear_combination_implementation.h
@@ -253,7 +253,7 @@ cgpt_Lattice_base* cgpt_compatible_linear_combination(Lattice<T>& _compatible,cg
     return cgpt_lc<T,BIT_COLORTRACE>(dst,ac,f,unary_factor);
   } else if (unary_expr == BIT_SPINTRACE) {
     return cgpt_lc<T,BIT_SPINTRACE>(dst,ac,f,unary_factor);
-  } else if (unary_expr == BIT_COLORTRACE|BIT_SPINTRACE) {
+  } else if (unary_expr == (BIT_COLORTRACE|BIT_SPINTRACE)) {
     return cgpt_lc<T,BIT_COLORTRACE|BIT_SPINTRACE>(dst,ac,f,unary_factor);
   } else {
     ERR("Invalid unary_expr = %d",unary_expr);


### PR DESCRIPTION
This has been detected while adding the icpx compiler to RQCD CI. This compiler (and probably clang as well) show a warning:

```
cgpt/lib/instantiate/../expression/linear_combination_implementation.h:256:42:
warning: | has lower precedence than ==; == will be evaluated first [-Wparentheses]
  } else if (unary_expr == BIT_COLORTRACE|BIT_SPINTRACE) {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
cgpt/lib/instantiate/../expression/linear_combination_implementation.h:256:42:
note: place parentheses around the '==' expression to silence this warning
  } else if (unary_expr == BIT_COLORTRACE|BIT_SPINTRACE) {
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
cgpt/lib/instantiate/../expression/linear_combination_implementation.h:256:42:
note: place parentheses around the | expression to evaluate it first
  } else if (unary_expr == BIT_COLORTRACE|BIT_SPINTRACE) {
                           ~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```

I haven't check the code in details, but I assume this is actually not a warning, but an error. I.e. we want to add the parantheses as suggested by the compiler to evaluate the | expression first. If it is indeed on purpose one should add parantheses to make this clear.