### PR TITLE
add preconditioned CG

### DIFF
--- a/lib/gpt/algorithms/inverter/cg.py
+++ b/lib/gpt/algorithms/inverter/cg.py
@@ -29,53 +29,70 @@ class cg(base_iterative):
         self.eps = params["eps"]
         self.maxiter = params["maxiter"]
 
-    def __call__(self, mat):
+    def __call__(self, mat, approx_inv_mat=None):
 
+        # remove wrapper for performance benefits
         otype, grid, cb = None, None, None
         if type(mat) == g.matrix_operator:
             otype, grid, cb = mat.otype, mat.grid, mat.cb
             mat = mat.mat
-            # remove wrapper for performance benefits
+        if type(approx_inv_mat) == g.matrix_operator:
+            approx_inv_mat = approx_inv_mat.mat
 
         @self.timed_function
         def inv(psi, src, t):
             assert src != psi
             t("setup")
             p, mmp, r = g.copy(src), g.copy(src), g.copy(src)
+            if approx_inv_mat is not None:
+                z = g.copy(src)
+            else:
+                z = r  # reference the same lattice object
             mat(mmp, psi)  # in, out
             d = g.inner_product(psi, mmp).real
             b = g.norm2(mmp)
             r @= src - mmp
-            p @= r
-            a = g.norm2(p)
-            cp = a
+            if approx_inv_mat is not None:
+                approx_inv_mat(z, r)
+            p @= z
+            cp = g.inner_product(r, z).real  # this is always real
             ssq = g.norm2(src)
             if ssq == 0.0:
-                assert a != 0.0  # need either source or psi to not be zero
-                ssq = a
+                assert cp != 0.0  # need either source or psi to not be zero
+                ssq = cp
             rsq = self.eps ** 2.0 * ssq
             for k in range(self.maxiter):
                 c = cp
+
                 t("matrix")
                 mat(mmp, p)
+
                 t("inner_product")
-                dc = g.inner_product(p, mmp)
-                d = dc.real
+                d = g.inner_product(p, mmp).real
                 a = c / d
+
                 t("axpy_norm2")
-                cp = g.axpy_norm2(r, -a, mmp, r)
+                norm_r = g.axpy_norm2(r, -a, mmp, r)
+                if approx_inv_mat is None:
+                    cp = norm_r
+                else:
+                    t("preconditioner")
+                    approx_inv_mat(z, r)
+                    cp = g.inner_product(r, z).real
+
                 t("linear combination")
                 b = cp / c
                 psi += a * p
-                p @= b * p + r
+                p @= b * p + z
+
                 t("other")
-                self.log_convergence(k, cp, rsq)
-                if cp <= rsq:
+                self.log_convergence(k, norm_r, rsq)
+                if norm_r <= rsq:
                     self.log(f"converged in {k+1} iterations")
                     return
 
             self.log(
-                f"NOT converged in {k+1} iterations;  squared residual {cp:e} / {rsq:e}"
+                f"NOT converged in {k+1} iterations;  squared residual {norm_r:e} / {rsq:e}"
             )
 
         return g.matrix_operator(

--- a/lib/gpt/core/operator/matrix_operator.py
+++ b/lib/gpt/core/operator/matrix_operator.py
@@ -96,7 +96,7 @@ class matrix_operator(factor):
 
     def __mul__(self, other):
 
-        if type(other) == matrix_operator:
+        if isinstance(other, matrix_operator):
             # mat = self * other
             # mat^dag = other^dag self^dag
             # (mat^dag)^-1 = (other^dag self^dag)^-1 = self^dag^-1 other^dag^-1


### PR DESCRIPTION
add an (optional) preconditioner to CG. I have implemented as part of the existing cg class instead of a new class to reduce code-duplication. Running CG on a matrix `M` with preconditioner `P` is equivalent to running normal CG on the problem `(E^-1)^dag * M * E^-1` where `E^dag * E = P`. But the matrix `E` is never needed in isolation, only `P` (or rather `P^-1`).

`gpt.algorithms.inverter.preconditioned` already allows arbitrary preconditioners of the form `L* M * R + S` for any matrices `L,M,S`. But both `L` and `R` need both be actually exist separately, which can be quite inconvenient.

My usecase (if anyone cares):
Wilson-Clover fermions have the form "M=Clover+Hopping". When running nf=2 simulations, I need to invert "M^dag M". The simplest preconditioner for that operator consists simply of the site-local part of "M^dag M", which turns out to be "C^dag C + 4" (the "+4" comes from the "H^dag H" term). In order to use `gpt.algorithms.inverter.preconditioned`, I would need to compute the square-root of that operator, which is not needed when using preconditioned CG directly. (just setting "L=(C^dag C+4)^-1" and "R=1" is not an option either, because that would destroy self-adjointness and make CG unusable altogether)