### PR TITLE
Juwels Booster Bootstrap Update

### DIFF
--- a/scripts/bootstrap/juwels-booster.nvcc.gpu.mpi
+++ b/scripts/bootstrap/juwels-booster.nvcc.gpu.mpi
@@ -4,8 +4,8 @@
 #
 module purge
 
-module load GCC/9.3.0
-module load OpenMPI/4.1.0rc1
+module load GCC/10.3.0
+module load OpenMPI/4.1.1
 module load mpi-settings/CUDA
 
 #


### PR DESCRIPTION
Update compiler module for the Juwels Booster Bootstrap.
Cuda compiler versions 11.0 and 11.1 are no longer supported.
See Grid issue 346: https://github.com/paboyle/Grid/issues/346