### PR TITLE
fix grouped inversion

### DIFF
--- a/lib/gpt/core/operator/matrix_operator.py
+++ b/lib/gpt/core/operator/matrix_operator.py
@@ -182,7 +182,7 @@ class matrix_operator(factor):
 
     def grouped(self, max_group_size):
         def _grouped(dst, src, mat):
-            n = self.lhs_length(src)
+            n = 1
             for i in range(0, len(src), max_group_size):
                 mat(dst[i * n : (i + max_group_size) * n], src[i : i + max_group_size])
 


### PR DESCRIPTION
I don't understand this part of the code, so this change is likely not correct and may introduce other issues. But without this change, the grouped CG does not work. Before this change, n = 12 in CG.