### PR TITLE
Fixed missing source command in tests/run

### DIFF
--- a/tests/run
+++ b/tests/run
@@ -75,7 +75,7 @@ do
 printf "%-120s" " [TEST] $f"
 
 start=$SECONDS
-${runner} $f ${extra} 2>&1 > ${LOG}
+source ${runner} $f ${extra} 2>&1 > ${LOG}
 res=$?
 elapsed=$((SECONDS-start))
 


### PR DESCRIPTION
In `tests/run`, line 78, a `source` command is missing, which is required to run GPT's tests successfully.