### PR TITLE
initialized history of base_iterative in __init__

### DIFF
--- a/lib/gpt/algorithms/base.py
+++ b/lib/gpt/algorithms/base.py
@@ -70,6 +70,7 @@ class base_iterative(base):
         super().__init__(name)
         self.verbose_convergence = gpt.default.is_verbose(self.name + "_convergence")
         self.converged = None
+        self.history = []
 
     def log_convergence(self, iteration, value, target=None):
         if (type(iteration) == int and iteration == 0) or (


### PR DESCRIPTION
When iterative algorithm instances are created but not used, the history attribute is missing; this can yield unexpected attribute errors. Setting the history to an empty list in `__init__` avoids that.