### PR TITLE
Fix fom

### DIFF
--- a/lib/gpt/algorithms/inverter/fom.py
+++ b/lib/gpt/algorithms/inverter/fom.py
@@ -66,7 +66,7 @@ class fom(base_iterative):
 
             t("setup")
             rlen = self.restartlen
-            mmp, r = g.copy(src), g.copy(src)
+            mmp, r = g.lattice(src), g.lattice(src)
             r2 = self.calc_res(mat, psi, mmp, src, r)
 
             ssq = g.norm2(src)
@@ -117,7 +117,7 @@ class fom(base_iterative):
 
                 if self.maxiter != rlen:
                     t("restart")
-                    a.basis = [Q[-1]]
+                    a.basis = [g.eval(r / g.norm2(r) ** 0.5)]
                     a.H = []
                     self.debug("performed restart")
 


### PR DESCRIPTION
Calculation of Krylov basis after restart was wrong. See, e.g., vector $v_1$ of ALGORITHM 6.5 of [https://www-users.cse.umn.edu/~saad/IterMethBook_2ndEd.pdf](url).

This can be seen by running
```python
import gpt as g

# load configuration
precision = g.double
rng = g.random("test")
U = g.qcd.gauge.random(g.grid([4, 4, 4, 8], precision), rng)

# use the gauge configuration grid
grid = U[0].grid

# quark
w = g.qcd.fermion.wilson_clover(
    U,
    {
        "kappa": 0.13565,
        "csw_r": 2.0171 / 2.0,
        "csw_t": 2.0171 / 2.0,
        "xi_0": 1,
        "nu": 1,
        "isAnisotropic": False,
        "boundary_phases": [1.0, 1.0, 1.0, 1.0],
    },
)

# create point source
src = g.vspincolor(grid)
src[:] = 0
src[0, 1, 0, 0] = g.vspincolor([[1] * 3] * 4)

# solver
inv = g.algorithms.inverter
fom = inv.fom({"eps": 1e-6, "maxiter": 1000, "restartlen": 20})(w)

dst = g.eval(fom * src)

# Output before pull request
# fom: NOT converged in 1000 iterations;
# computed squared residual 2.433503e-07 / 1.200000e-11;
# true squared residual 3.202319e+00 / 1.200000e-11

# Output after pull request
# fom: NOT converged in 1000 iterations;
# computed squared residual 2.433503e-07 / 1.200000e-11;
# true squared residual 2.433503e-07 / 1.200000e-11
``` 
and compare computed squared residual and true squared residual.