### PR TITLE
Fix inverse_phat_square

### DIFF
--- a/lib/gpt/algorithms/optimize/fourier_accelerate.py
+++ b/lib/gpt/algorithms/optimize/fourier_accelerate.py
@@ -44,7 +44,7 @@ class inverse_phat_square(differentiable_functional):
             self.weight += c_mu_l
 
         # special consideration for zero
-        self.weight[0, 0, 0, 0] = (2.0 * np.pi) ** 2.0 / np.prod(
+        self.weight[coor[0:1]] = (2.0 * np.pi) ** 2.0 / np.prod(
             [grid.gdimensions[mu] for mu in dimensions]
         ) ** (2.0 / len(dimensions))
 

--- a/lib/gpt/algorithms/optimize/fourier_accelerate.py
+++ b/lib/gpt/algorithms/optimize/fourier_accelerate.py
@@ -44,7 +44,7 @@ class inverse_phat_square(differentiable_functional):
             self.weight += c_mu_l
 
         # special consideration for zero
-        self.weight[coor[0:1]] = (2.0 * np.pi) ** 2.0 / np.prod(
+        self.weight[[[0] * grid.nd]] = (2.0 * np.pi) ** 2.0 / np.prod(
             [grid.gdimensions[mu] for mu in dimensions]
         ) ** (2.0 / len(dimensions))
 


### PR DESCRIPTION
In line
https://github.com/lehner/gpt/blob/ea0ed0ee1a7690201d0329e23a90a1e1c0a51513/lib/gpt/algorithms/optimize/fourier_accelerate.py#L29
`dimensions` can be arbitrary, but line
https://github.com/lehner/gpt/blob/ea0ed0ee1a7690201d0329e23a90a1e1c0a51513/lib/gpt/algorithms/optimize/fourier_accelerate.py#L47
only works for `dimensions` equals 4.
This can be fixed by changing `self.weight[0, 0, 0, 0]` to `self.weight[coor[0:1]]`.