### PR TITLE
Fix design problem multi_shift

### DIFF
--- a/tests/algorithms/solvers.py
+++ b/tests/algorithms/solvers.py
@@ -179,7 +179,7 @@ assert all([h * 1.5 < history[0] for h in history[1:]])
 # ordering of dst fields.
 
 cg = inv.cg({"eps": 1e-8, "maxiter": 500})
-shifts = [0.5, 1.0, 1.7]
+shifts = [0.5, 1.7, 1.0]
 mat = eo2_odd(w).Mpc
 
 # also test with multiple sources
@@ -197,24 +197,28 @@ g.default.set_verbose("multi_shift_cg")
 mscg = inv.multi_shift_cg({"eps": 1e-8, "maxiter": 1024, "shifts": shifts})
 
 g.default.set_verbose("multi_shift_fom")
-msfom = inv.multi_shift_fom({"eps": 1e-8, "maxiter": 1024, "restartlen": 10, "shifts": shifts})
+msfom = inv.multi_shift_fom({"eps": 1e-8, "maxiter": 1024, "restartlen": 4, "shifts": shifts})
 
 g.default.set_verbose("multi_shift_fgmres")
 msfgmres = inv.multi_shift_fgmres(
-    {"eps": 1e-8, "maxiter": 1024, "restartlen": 10, "shifts": shifts}
+    {"eps": 1e-8, "maxiter": 1024, "restartlen": 4, "shifts": shifts}
 )
 
+g.default.set_verbose("multi_shift_fom", False)
 prec_fom = inv.multi_shift_fom({"maxiter": 4, "restartlen": 2})
+g.default.set_verbose("multi_shift_fgmres")
 msfgmres_fom = inv.multi_shift_fgmres(
-    {"eps": 1e-8, "maxiter": 512, "restartlen": 5, "shifts": shifts, "prec": prec_fom}
+    {"eps": 1e-8, "maxiter": 512, "restartlen": 2, "shifts": shifts, "prec": prec_fom}
 )
 
+g.default.set_verbose("multi_shift_fgmres", False)
 prec_fgmres = inv.multi_shift_fgmres({"maxiter": 4, "restartlen": 2})
+g.default.set_verbose("multi_shift_fgmres")
 msfgmres_fgmres = inv.multi_shift_fgmres(
     {
         "eps": 1e-8,
         "maxiter": 512,
-        "restartlen": 5,
+        "restartlen": 2,
         "shifts": shifts,
         "prec": prec_fgmres,
     }


### PR DESCRIPTION
 Changes of the pull request:

- Fix design problem with `multi_shift_fom` and `multi_shift_fgmres`. Instead of returning $\rho$ values for preconditioned FGMRES, save the values as an instance variable.

- Sort shifts in multi_shift_fgmres. Sorting shifts in GMRES can improve convergence, see e.g. [https://doi.org/10.1137/S1064827596304563](url).

- Smaller restart size for tests of  `multi_shift_fom` and `multi_shift_fgmres`. By using a smaller restart size, shifts can converge at different iterations. This change allows for testing the handling of already converged shifts.