### PR TITLE
fixed a bug in corr_io: UTF-8 tag encoding was broken [TINY]

### DIFF
--- a/lib/gpt/core/io/corr_io.py
+++ b/lib/gpt/core/io/corr_io.py
@@ -28,8 +28,9 @@ class writer:
 
     def write(self, t, cc):
         if self.f is not None:
-            self.f.write(struct.pack("i", len(t) + 1))
-            self.f.write((t + "\0").encode("utf-8"))
+            tag_data = (t + "\0").encode("utf-8")
+            self.f.write(struct.pack("i", len(tag_data)))
+            self.f.write(tag_data)
             ln = len(cc)
             ccr = [fff for sublist in ((c.real, c.imag) for c in cc) for fff in sublist]
             bindata = struct.pack("d" * 2 * ln, *ccr)


### PR DESCRIPTION
When characters in tags were more-than-one-byte encoded by UTF-8, the length of the tag was computed wrongly. This led to seemingly corrupted data when reading.