### PR TITLE
Reverse AD containing scalar nodes

### DIFF
--- a/lib/gpt/ad/reverse/foundation/__init__.py
+++ b/lib/gpt/ad/reverse/foundation/__init__.py
@@ -188,3 +188,8 @@ def cshift_plan_execute(self):
         return ret
 
     return _executer
+
+def group_inner_product(left, right):
+    # inner product over group's real vector space
+    left_type = left.otype
+    return left_type.inner_product(left, right)

--- a/lib/gpt/ad/reverse/node.py
+++ b/lib/gpt/ad/reverse/node.py
@@ -26,7 +26,7 @@ from gpt.ad.reverse.util import (
 )
 from gpt.ad.reverse import foundation
 from gpt.core.foundation import base
-
+import numpy as np
 verbose_memory = g.default.is_verbose("ad_memory")
 
 
@@ -225,7 +225,14 @@ class node_base(base):
         # not allowed to capture z, otherwise have reference loop!
         def _backward(z):
             if x.with_gradient:
-                setter(x.gradient, getter(x.gradient) + z.gradient)
+                set_to = getter(x.gradient) + z.gradient
+                
+                #passing immutables to the setter results in the output not being set
+                #work around this by directly assigning numerical types
+                if isinstance(x.gradient, (int, float, complex, np.generic)):
+                    x.gradient = set_to
+                else:
+                    setter(x.gradient, set_to)
 
         z_container = get_unary_container(x._container, getter)
 


### PR DESCRIPTION
This request fixes an issue with reverse differentiation involving nodes whose underlying type is immutable (e.g. numbers), specifically for graphs where the "project" function (called by, e.g, node_base.real).

Firstly, it appears the setter for node_base.real is designed only for types that support the @= operator, which is not true for immutable types. The example code
```
import gpt as g
import numpy as np

rng = g.random("1234")
grid = g.grid([4, 4, 4, 4], g.double)
U = g.qcd.gauge.random(grid, rng, scale=2.0)

import gpt.ad.reverse as rad

def testModel(field):
    return g.sum(g.trace(field)).real

field = g.copy(U[0])
field_n = rad.node(field)

m = testModel(field_n)

m_f = m.functional(field_n)
m_val = m_f([field])
print(m_val, type(m_val))

grad = m_f.gradient([field], [field])
print(grad, type(grad[0]))
```

throws the error:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[6], line 4
      1 m_f = m.functional(field_n)
      2 m_val = m_f([field])
      3 print(m_val, type(m_val))
----> 4 grad = m_f.gradient([field], [field])
      5 print(grad, type(grad[0]))

File [~/src/gpt/lib/gpt/ad/reverse/node.py:80](http://127.0.0.1:8888/home/ckelly/src/gpt/lib/gpt/ad/reverse/node.py#line=79), in node_differentiable_functional.gradient(self, fields, dfields)
     78 for i in range(len(fields)):
     79     self.arguments[i].value = fields[i]
---> 80 self.node()
     81 return [self.arguments[i].gradient for i in indices]

File [~/src/gpt/lib/gpt/ad/reverse/node.py:356](http://127.0.0.1:8888/home/ckelly/src/gpt/lib/gpt/ad/reverse/node.py#line=355), in node_base.__call__(self, with_gradients, initial_gradient)
    354 self.forward(nodes, free=forward_free if not with_gradients else None)
    355 if with_gradients:
--> 356     self.backward(nodes, first_gradient=forward_free, initial_gradient=initial_gradient)
    357 nodes = None
    358 return self.value

File [~/src/gpt/lib/gpt/ad/reverse/node.py:334](http://127.0.0.1:8888/home/ckelly/src/gpt/lib/gpt/ad/reverse/node.py#line=333), in node_base.backward(self, nodes, first_gradient, initial_gradient)
    332         fields_allocated += 1
    333         max_fields_allocated = max(max_fields_allocated, fields_allocated)
--> 334 n._backward(n)
    335 if n._forward is not None:
    336     n.gradient = None

File [~/src/gpt/lib/gpt/ad/reverse/node.py:228](http://127.0.0.1:8888/home/ckelly/src/gpt/lib/gpt/ad/reverse/node.py#line=227), in node_base.project.<locals>._backward(z)
    226 def _backward(z):
    227     if x.with_gradient:
--> 228         setter(x.gradient, getter(x.gradient) + z.gradient)

File [~/src/gpt/lib/gpt/ad/reverse/node.py:377](http://127.0.0.1:8888/home/ckelly/src/gpt/lib/gpt/ad/reverse/node.py#line=376), in node_base.get_real.<locals>.setter(y, z)
    376 def setter(y, z):
--> 377     y @= z

TypeError: unsupported operand type(s) for @=: 'float' and 'float'
```

However a larger problem is that the setter pattern itself does not work for immutable types, e.g. calling
```
def setter(x,y):
   x=y

x=float(1.23)
setter(x, 3.14)

print(x)
```
gives 1.23, not 3.14 because reassignment of immutables creates a new object even though x is passed by reference(!), a wonderful Pythonic footgun. This PR adds a workaround that performs direct assignment in the majority of cases when the assignee is immutable (note I originally used core.util.is_num but your quad-precision numbers are mutable containers) :

```
        def _backward(z):
            if x.with_gradient:
                set_to = getter(x.gradient) + z.gradient

                #passing immutables to the setter results in the output not being set
                #work around this by directly assigning numerical types
                if isinstance(x.gradient, (int, float, complex, np.generic)):
                    x.gradient = set_to
                else:
                    setter(x.gradient, set_to)
```

This solution will fail if "setter" performs any non-trivial operation on the set value, but I don't think that is the intent of setter. An alternative solution might be to temporarily wrap x.gradient in a class that does support @=, I'll leave that to your discretion.

Note, this PR also adds support for group_inner_product to the reverse AD, which allows correct differentiation of functions invoking this operation (e.g. mass_term).





